### PR TITLE
Add bilingual issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_en.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_en.yml
@@ -1,0 +1,112 @@
+name: "Bug report (EN)"
+description: "Report a reproducible Gluetun Companion problem"
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting this problem. Remove private keys, tokens, passwords, and other secrets before submitting.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Preliminary checks
+      options:
+        - label: I am using a recent version of Gluetun Companion.
+          required: true
+        - label: I searched for an existing issue describing the same problem.
+          required: true
+        - label: I removed all sensitive data from the information provided.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Gluetun Companion version
+      description: Provide the Docker image tag, release version, or commit in use.
+      placeholder: "Example: latest, v1.2.3, or abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Operating mode
+      options:
+        - Sidecar
+        - Proxy only
+        - Other / Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: gluetun_version
+    attributes:
+      label: Gluetun version
+      placeholder: "Example: qmcgaw/gluetun:v3.40.0"
+
+  - type: input
+    id: provider
+    attributes:
+      label: VPN provider
+      placeholder: "Example: AirVPN, Mullvad, Proton VPN"
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: Clearly describe what happened and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open...
+        2. Configure...
+        3. Click...
+        4. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: compose
+    attributes:
+      label: Relevant Docker configuration
+      description: Include only relevant services and variables, without secrets.
+      render: yaml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Add Gluetun Companion, sidecar, or Gluetun logs around the problem.
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - Operating system:
+        - Architecture: amd64 / arm64
+        - Browser:
+        - Docker / Docker Compose:
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, frequency, or any other useful information.
+

--- a/.github/ISSUE_TEMPLATE/bug_report_fr.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_fr.yml
@@ -1,0 +1,112 @@
+name: "Rapport de bug (FR)"
+description: "Signaler un dysfonctionnement reproductible de Gluetun Companion"
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de prendre le temps de signaler ce problème. Retirez les clés privées, tokens, mots de passe et autres secrets avant de publier.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Vérifications préalables
+      options:
+        - label: J'utilise une version récente de Gluetun Companion.
+          required: true
+        - label: J'ai recherché une issue existante décrivant le même problème.
+          required: true
+        - label: J'ai retiré toutes les données sensibles des informations fournies.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version de Gluetun Companion
+      description: Indiquez le tag de l'image Docker, la version ou le commit utilisé.
+      placeholder: "Exemple : latest, v1.2.3 ou abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Mode utilisé
+      options:
+        - Sidecar
+        - Proxy uniquement
+        - Autre / Je ne sais pas
+    validations:
+      required: true
+
+  - type: input
+    id: gluetun_version
+    attributes:
+      label: Version de Gluetun
+      placeholder: "Exemple : qmcgaw/gluetun:v3.40.0"
+
+  - type: input
+    id: provider
+    attributes:
+      label: Fournisseur VPN
+      placeholder: "Exemple : AirVPN, Mullvad, Proton VPN"
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Description du problème
+      description: Décrivez clairement le comportement observé et son impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Étapes pour reproduire
+      placeholder: |
+        1. Ouvrir...
+        2. Configurer...
+        3. Cliquer sur...
+        4. Constater...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportement attendu
+    validations:
+      required: true
+
+  - type: textarea
+    id: compose
+    attributes:
+      label: Configuration Docker pertinente
+      description: Collez uniquement les services et variables utiles, sans secrets.
+      render: yaml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs pertinents
+      description: Ajoutez les logs de Gluetun Companion, du sidecar ou de Gluetun autour du problème.
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environnement
+      placeholder: |
+        - Système d'exploitation :
+        - Architecture : amd64 / arm64
+        - Navigateur :
+        - Docker / Docker Compose :
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Informations complémentaires
+      description: Captures d'écran, fréquence du problème ou tout autre contexte utile.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request_en.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_en.yml
@@ -1,0 +1,57 @@
+name: "Feature request (EN)"
+description: "Suggest an improvement or a new feature"
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion. Focus on the need first; the technical solution can be discussed afterward.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Preliminary checks
+      options:
+        - label: I searched for an existing request covering the same need.
+          required: true
+        - label: This request concerns Gluetun Companion rather than Gluetun itself.
+          required: true
+
+  - type: textarea
+    id: need
+    attributes:
+      label: Need or problem
+      description: What is currently difficult or impossible to achieve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed feature
+      description: Describe the desired behavior from the user's perspective.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Provide a concrete example of how this feature would be used.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Current workarounds or other possible solutions.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links, or constraints to consider.
+

--- a/.github/ISSUE_TEMPLATE/feature_request_fr.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_fr.yml
@@ -1,0 +1,57 @@
+name: "Demande de fonctionnalité (FR)"
+description: "Proposer une amélioration ou une nouvelle fonctionnalité"
+title: "[Fonctionnalité] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci pour votre proposition. Décrivez surtout le besoin à résoudre ; une solution technique peut ensuite être discutée.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Vérifications préalables
+      options:
+        - label: J'ai recherché une demande existante portant sur le même besoin.
+          required: true
+        - label: Cette demande concerne Gluetun Companion et non Gluetun lui-même.
+          required: true
+
+  - type: textarea
+    id: need
+    attributes:
+      label: Besoin ou problème
+      description: Quel usage est actuellement difficile ou impossible ?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Fonctionnalité proposée
+      description: Décrivez le comportement souhaité du point de vue utilisateur.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Cas d'utilisation
+      description: Donnez un exemple concret montrant comment cette fonctionnalité serait utilisée.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives envisagées
+      description: Contournements actuels ou autres solutions possibles.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Informations complémentaires
+      description: Maquettes, captures, liens ou contraintes à prendre en compte.
+


### PR DESCRIPTION
## Summary

- add French and English bug report forms
- add French and English feature request forms
- disable blank issues to guide contributors toward structured reports

## Validation

- parsed all issue forms successfully as YAML
- verified required GitHub issue form fields