### PR TITLE
Correction des clés dupliquées dans l’override Compose

### DIFF
--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -213,8 +213,20 @@ def switch_server(
             profile_vars = dict(wg_profile.get('vars') or {})
         else:
             profile_vars = dict(wg_profile.get('extra_env') or {})
-            compose_provider = compose_provider or profile_vars.pop('VPN_SERVICE_PROVIDER', '')
-            profile_vars.pop('VPN_TYPE', None)
+        compose_provider = compose_provider or profile_vars.get('VPN_SERVICE_PROVIDER', '')
+
+        # These values are generated explicitly below. Profiles imported from
+        # older code paths can still contain them, which would otherwise emit
+        # duplicate YAML mapping keys and make Docker Compose reject the file.
+        managed_vars = {
+            'VPN_SERVICE_PROVIDER',
+            'VPN_TYPE',
+            *FILTER_VARS.values(),
+        }
+        profile_vars = {
+            key: value for key, value in profile_vars.items()
+            if key not in managed_vars
+        }
 
     uses_server_filter = compose_provider != 'custom'
 

--- a/tests/test_gluetun_override.py
+++ b/tests/test_gluetun_override.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.gluetun import switch_server
+
+
+class SwitchServerOverrideTest(TestCase):
+    def test_deduplicates_managed_profile_variables(self) -> None:
+        profile = {
+            'compose_provider': 'airvpn',
+            'vars': {
+                'VPN_SERVICE_PROVIDER': 'airvpn',
+                'VPN_TYPE': 'wireguard',
+                'SERVER_NAMES': 'must-not-override-selection',
+                'WIREGUARD_PRIVATE_KEY': 'private-key',
+                'WIREGUARD_PRESHARED_KEY': 'preshared-key',
+                'WIREGUARD_ADDRESSES': '10.146.38.51/32',
+            },
+        }
+
+        with TemporaryDirectory() as directory:
+            with (
+                patch('app.gluetun._detect_compose_project', return_value='airvpn'),
+                patch('app.gluetun._detect_compose_service', return_value='gluetun-airvpn'),
+                patch('app.gluetun.mark_companion_restart'),
+                patch('app.gluetun.subprocess.run') as run,
+            ):
+                run.return_value.returncode = 0
+                run.return_value.stderr = ''
+                run.return_value.stdout = ''
+                success, error = switch_server(
+                    'Dalim',
+                    'server_names',
+                    'gluetun-airvpn',
+                    directory,
+                    wg_profile=profile,
+                )
+
+                override = (Path(directory) / 'docker-compose.override.yml').read_text()
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertEqual(override.count('VPN_SERVICE_PROVIDER:'), 1)
+        self.assertEqual(override.count('VPN_TYPE:'), 1)
+        self.assertEqual(override.count('SERVER_NAMES:'), 1)
+        self.assertIn('SERVER_NAMES: "Dalim"', override)
+        self.assertEqual(override.count('WIREGUARD_PRIVATE_KEY:'), 1)


### PR DESCRIPTION
## Résumé

- empêche la génération en double de `VPN_SERVICE_PROVIDER`, `VPN_TYPE` et des filtres serveur dans l’override Compose
- conserve les identifiants WireGuard provenant des profils VPN
- ajoute un test de non-régression couvrant un profil AirVPN contenant les anciennes variables gérées

## Validation

- `python -m unittest tests.test_gluetun_override -v`
- `python -m compileall -q app tests`
- validation de la stack AirVPN réparée avec `docker compose config`
- builds Companion et Sidecar réussis

Corrige l’erreur de clé dupliquée `VPN_SERVICE_PROVIDER`.
