### PR TITLE
Améliore la gestion du port forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# ── Notes privées de session (Claude / Codex) — ne jamais publier ──────────
+claude_*.txt
+rapport_*.txt
+CHANTIER.md
+
+# ── Python ──────────────────────────────────────────────────────────────────
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# ── Données runtime ─────────────────────────────────────────────────────────
+data/
+*.db
+*.db-wal
+*.db-shm
+
+# ── IDE / OS ─────────────────────────────────────────────────────────────────
+.idea/
+.vscode/
+*.swp
+.DS_Store
+Thumbs.db

--- a/README.en.md
+++ b/README.en.md
@@ -198,7 +198,7 @@ Primarily designed and tested for **[AirVPN](https://airvpn.org/?referred_by=483
 - **Per-URL control** — each tracker can be enabled or ignored individually for future checks
 - **VPN compatibility score** — enabled trackers are checked through the VPN path; by default, 80% success is enough to consider the server compatible, avoiding false negatives when a single tracker is down
 - **Optional switch criterion** — when enabled, a benchmarked server below the tracker threshold is excluded from the auto-switch pick; pools ignore servers already known as tracker-incompatible
-- **Per-provider port forwarding** — declare AirVPN/manual, Gluetun-native or custom rules in **Settings → Port Forwarding**; when automation is enabled, Companion applies the new provider's rules after a Gluetun switch and resynchronizes qBittorrent or configured hooks
+- **Per-provider port forwarding** — declare AirVPN/manual, Gluetun-native (`/v1/portforward`) or custom rules in **Settings → Port Forwarding**; when automation is enabled, Companion applies the new provider's rules after every switch (manual, benchmark, pool rotation), resynchronizes qBittorrent or rTorrent *(beta)* and runs the configured `on_port_change` hooks; a periodic check also catches port renewals that happen without a container restart
 
 ### AirVPN
 - **Built-in AirVPN server picker** — *+ Add AirVPN servers* button on the Servers page: live data from `airvpn.org/api/status/` (5-min server-side cache), four tabs — full searchable list, geographic distribution by country, **Recommended** tab (load < 70 %, bandwidth ≥ 5 Gbit/s) and **Changes** tab (newly detected servers, disappeared servers, load shifts, top 5 healthiest countries); multi-select, one-click add
@@ -451,7 +451,7 @@ In **Settings → Port Forwarding**, Companion manages incoming ports required b
 
 - **Disabled** — rules remain stored but are not applied.
 - **Manual active** — rules can be declared, checked and synchronized on demand.
-- **Automatic active** — when Gluetun switches to another VPN provider, Companion automatically applies the new provider's rules. After a Docker-detected Gluetun reconnection, Companion also rereads the native port and propagates it when needed.
+- **Automatic active** — when Gluetun switches to another VPN provider (manual switch, benchmark **or pool rotation**), Companion automatically applies the new provider's rules. After a Docker-detected Gluetun reconnection, Companion also rereads the native port and propagates it when needed. Finally, a **periodic check (every 5 min)** compares the native `/v1/portforward` port to the last applied port: if Gluetun renewed the port **without a container restart** (e.g. NAT-PMP renewal), the rules are re-applied automatically.
 
 Each entry contains:
 
@@ -471,7 +471,7 @@ For each declared port, the UI shows:
 - whether the port is published on the Gluetun Docker container, per protocol;
 - qBittorrent listen port when the entry is linked to a qBittorrent client.
 
-The **Sync qBittorrent** button updates qBittorrent's `listen_port` through the Web API (`/api/v2/app/setPreferences`) with the applicable port. In **Gluetun native** mode, Companion first reads the Gluetun Control Server (`GET /v1/portforward`) and then pushes the returned port to qBittorrent.
+The **Sync** button updates the linked client's listen port: qBittorrent through the Web API (`/api/v2/app/setPreferences` + read-back verification), or **rTorrent via XML-RPC** (`network.port_range.set` + read-back — *beta support, implemented against the XML-RPC spec but not yet validated on a live rTorrent instance; the `on_port_change` hook remains available as a fallback*). In **Gluetun native** mode, Companion first reads the Gluetun Control Server (`GET /v1/portforward`) and then pushes the returned port to the client.
 
 To enable Gluetun native support, configure Gluetun with [`VPN_PORT_FORWARDING=on`](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/port-forwarding.md) and expose its [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). In Companion, set the URL, for example `http://host.docker.internal:8967` when Docker publishes `8967:8000`. If Gluetun uses `apikey` authentication, also enter the `X-API-Key` value. Companion uses `/v1/portforward` as the primary source; the historical Gluetun status file is not used as the preferred source because Gluetun documents it as eventually deprecated.
 
@@ -484,7 +484,7 @@ For AirVPN, Companion does not create the port in the AirVPN panel. The expected
 5. link the port to the relevant qBittorrent client or add an `on_port_change` command;
 6. enable automatic application if rules should follow VPN provider changes.
 
-For rTorrent/ruTorrent and personal WireGuard servers, Companion does not arbitrarily edit configuration files. Use `on_port_change` to call a controlled script or command instead. Available variables are `{port}`, `{provider}`, `{name}`, `{protocols}` and `{client}`. Example:
+For rTorrent/ruTorrent, simply link an rTorrent-type client to the rule: XML-RPC synchronisation applies automatically *(beta — see above)*. For other clients, personal WireGuard servers or any specific need, use `on_port_change` to call a controlled script or command. Available variables are `{port}`, `{provider}`, `{name}`, `{protocols}` and `{client}`. Example:
 
 ```bash
 /compose/hooks/update-rtorrent-port.sh {port}

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Conçu et testé en priorité pour **[AirVPN](https://airvpn.org/?referred_by=48
 - **Contrôle par URL** — chaque tracker peut être activé ou ignoré individuellement pour les vérifications futures
 - **Score de compatibilité VPN** — les trackers activés sont testés depuis le chemin VPN ; par défaut, 80 % de réussite suffit pour considérer le serveur compatible afin d'éviter les faux négatifs quand un tracker est simplement down
 - **Critère de bascule optionnel** — si l'option est activée, un serveur benchmarké sous le seuil trackers est exclu du choix auto-switch ; les pools ignorent les serveurs déjà connus comme incompatibles
-- **Port forwarding par fournisseur** — déclarez des règles AirVPN/manual, Gluetun natif ou custom dans **Paramètres → Port Forwarding** ; si l’automatisme est activé, Companion applique les règles du nouveau fournisseur quand Gluetun bascule et resynchronise qBittorrent ou les hooks configurés
+- **Port forwarding par fournisseur** — déclarez des règles AirVPN/manual, Gluetun natif (`/v1/portforward`) ou custom dans **Paramètres → Port Forwarding** ; si l'automatisme est activé, Companion applique les règles du nouveau fournisseur à chaque bascule (manuelle, benchmark, rotation de pool), resynchronise qBittorrent ou rTorrent *(bêta)* et exécute les hooks `on_port_change` configurés ; un contrôle périodique détecte aussi les renouvellements de port sans redémarrage
 
 ### AirVPN
 - **Sélecteur de serveurs AirVPN intégré** — bouton *+ Ajouter des serveurs AirVPN* sur la page Serveurs : données en direct depuis `airvpn.org/api/status/` (cache 5 min), quatre onglets — liste complète searchable, répartition géographique par pays, onglet **Recommandés** (charge < 70 %, bande passante ≥ 5 Gbit/s) et onglet **Changements** (nouveaux serveurs détectés, serveurs disparus, évolutions de charge, top 5 pays les plus sains) ; ajout multi-sélection en un clic
@@ -451,7 +451,7 @@ Dans **Paramètres → Port Forwarding**, Companion gère les ports entrants né
 
 - **Désactivé** — les règles restent stockées mais ne sont pas appliquées.
 - **Actif manuel** — les règles peuvent être déclarées, vérifiées et synchronisées à la demande.
-- **Actif automatique** — quand Gluetun bascule vers un autre fournisseur VPN, Companion applique automatiquement les règles du nouveau fournisseur. Après une reconnexion Gluetun détectée par Docker, Companion relit aussi le port natif et le propage si nécessaire.
+- **Actif automatique** — quand Gluetun bascule vers un autre fournisseur VPN (bascule manuelle, benchmark **ou rotation de pool**), Companion applique automatiquement les règles du nouveau fournisseur. Après une reconnexion Gluetun détectée par Docker, Companion relit aussi le port natif et le propage si nécessaire. Enfin, un **contrôle périodique (toutes les 5 min)** compare le port natif `/v1/portforward` au dernier port appliqué : si Gluetun a renouvelé le port **sans redémarrage du container** (renouvellement NAT-PMP par exemple), les règles sont réappliquées automatiquement.
 
 Chaque entrée contient :
 
@@ -471,7 +471,7 @@ Pour chaque port déclaré, l'interface affiche :
 - publication Docker du port sur le container Gluetun, par protocole ;
 - port d'écoute qBittorrent lorsque l'entrée est liée à un client qBittorrent.
 
-Le bouton **Synchroniser qBittorrent** met à jour le `listen_port` qBittorrent via l'API Web (`/api/v2/app/setPreferences`) avec le port applicable. En mode **Natif Gluetun**, Companion lit d'abord le Control Server Gluetun (`GET /v1/portforward`) puis pousse le port retourné vers qBittorrent.
+Le bouton **Synchroniser** met à jour le port d'écoute du client lié : qBittorrent via l'API Web (`/api/v2/app/setPreferences` + relecture de vérification), ou **rTorrent via XML-RPC** (`network.port_range.set` + relecture — *support bêta, implémenté selon la spec XML-RPC mais pas encore validé sur une instance rTorrent réelle ; le hook `on_port_change` reste disponible en repli*). En mode **Natif Gluetun**, Companion lit d'abord le Control Server Gluetun (`GET /v1/portforward`) puis pousse le port retourné vers le client.
 
 Pour activer le support natif Gluetun, configurez Gluetun avec [`VPN_PORT_FORWARDING=on`](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/port-forwarding.md) et exposez son [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). Dans Companion, renseignez l'URL, par exemple `http://host.docker.internal:8967` si le port Docker `8967:8000` est publié. Si Gluetun utilise une auth `apikey`, renseignez aussi la valeur `X-API-Key`. Companion utilise `/v1/portforward` comme source principale ; le fichier de statut Gluetun historique n'est pas utilisé comme source prioritaire, car il est annoncé comme déprécié à terme par Gluetun.
 
@@ -484,7 +484,7 @@ Pour AirVPN, Companion ne crée pas le port sur le panel AirVPN. Le flux attendu
 5. lier le port au client qBittorrent concerné ou ajouter une commande `on_port_change` ;
 6. activer l’application automatique si les règles doivent suivre les changements de fournisseur VPN.
 
-Pour rTorrent/ruTorrent et les serveurs WireGuard personnels, Companion ne modifie pas arbitrairement les fichiers de configuration. Utilisez plutôt `on_port_change` pour appeler un script ou une commande maîtrisée. Les variables disponibles sont `{port}`, `{provider}`, `{name}`, `{protocols}` et `{client}`. Exemple :
+Pour rTorrent/ruTorrent, liez simplement un client de type rTorrent à la règle : la synchronisation XML-RPC s'applique automatiquement *(bêta — voir ci-dessus)*. Pour les autres clients, les serveurs WireGuard personnels ou tout besoin spécifique, utilisez `on_port_change` pour appeler un script ou une commande maîtrisée. Les variables disponibles sont `{port}`, `{provider}`, `{name}`, `{protocols}` et `{client}`. Exemple :
 
 ```bash
 /compose/hooks/update-rtorrent-port.sh {port}

--- a/app/port_forwarding.py
+++ b/app/port_forwarding.py
@@ -312,6 +312,69 @@ def sync_qbit_listen_port(port_forward_id: int, timeout: float = 6.0, port_overr
         return {'ok': False, 'error': str(exc)}
 
 
+def sync_rtorrent_listen_port(port_forward_id: int, timeout: float = 8.0, port_override: int | None = None) -> dict:
+    """Set rTorrent's listen port via XML-RPC (network.port_range.set).
+
+    ⚠ Beta: implemented against the rTorrent XML-RPC spec and the transport
+    already used for tracker discovery, but not yet validated against a live
+    rTorrent instance.  The custom on_port_change hook remains available as
+    a fallback.
+    """
+    pf = get_port_forward(port_forward_id)
+    if not pf:
+        return {'ok': False, 'error': 'Port forward introuvable.'}
+    if port_override is None and (pf.get('mode') or 'manual') == 'native':
+        native = read_gluetun_native_ports()
+        ports = native.get('ports') or []
+        if not ports:
+            return {'ok': False, 'error': native.get('error') or 'Port natif Gluetun indisponible.'}
+        port_override = int(ports[0])
+    client_id = int(pf.get('torrent_client_id') or 0)
+    client = get_torrent_client(client_id) if client_id else None
+    if not client:
+        return {'ok': False, 'error': 'Aucun client BitTorrent lié.'}
+    if client.get('client_type') != 'rtorrent':
+        return {'ok': False, 'error': 'Cette synchronisation est réservée à rTorrent.'}
+    port = int(port_override or pf.get('port') or 0)
+    if not (1 <= port <= 65535):
+        return {'ok': False, 'error': 'Port invalide.'}
+    try:
+        from .torrent_trackers import rtorrent_proxy
+        proxy = rtorrent_proxy(client, timeout=timeout)
+        rng = f'{port}-{port}'
+        proxy.network.port_range.set('', rng)
+        # Read back for verification; getter signature varies across versions
+        try:
+            current = proxy.network.port_range('')
+        except Exception:
+            try:
+                current = proxy.network.port_range()
+            except Exception:
+                current = None
+        if current is not None and str(port) not in str(current):
+            return {'ok': False, 'listen_port': str(current),
+                    'error': f'rTorrent a renvoyé "{current}" au lieu de "{rng}".'}
+        _set_last_applied_port(int(pf['id']), port)
+        return {'ok': True, 'listen_port': port, 'error': ''}
+    except Exception as exc:
+        return {'ok': False, 'error': str(exc)}
+
+
+def sync_client_listen_port(port_forward_id: int, timeout: float = 8.0, port_override: int | None = None) -> dict:
+    """Dispatch port sync to the right adapter based on the linked client type."""
+    pf = get_port_forward(port_forward_id)
+    if not pf:
+        return {'ok': False, 'error': 'Port forward introuvable.'}
+    client_id = int(pf.get('torrent_client_id') or 0)
+    client = get_torrent_client(client_id) if client_id else None
+    ctype = (client or {}).get('client_type') or ''
+    if ctype == 'qbittorrent':
+        return sync_qbit_listen_port(port_forward_id, timeout=timeout, port_override=port_override)
+    if ctype == 'rtorrent':
+        return sync_rtorrent_listen_port(port_forward_id, timeout=timeout, port_override=port_override)
+    return {'ok': False, 'error': 'Aucun client synchronisable lié (qBittorrent ou rTorrent).'}
+
+
 def apply_provider_port_forwards(
     provider: str,
     *,
@@ -384,7 +447,7 @@ def apply_provider_port_forwards(
                     result['skipped'] += 1
             result['details'].append(detail)
             continue
-        if pf.get('client_type') != 'qbittorrent':
+        if pf.get('client_type') not in ('qbittorrent', 'rtorrent'):
             if hook.get('skipped'):
                 detail.update({'skipped': True, 'error': 'Client non synchronisable automatiquement.'})
                 result['skipped'] += 1
@@ -398,14 +461,14 @@ def apply_provider_port_forwards(
 
         last = {'ok': False, 'error': ''}
         for attempt in range(max(1, retries)):
-            last = sync_qbit_listen_port(int(pf['id']), port_override=effective_port)
+            last = sync_client_listen_port(int(pf['id']), port_override=effective_port)
             if last.get('ok'):
                 break
             if attempt < retries - 1:
                 time.sleep(max(0.0, retry_delay))
-        qbit_ok = bool(last.get('ok'))
+        sync_ok = bool(last.get('ok'))
         hook_ok = bool(hook.get('ok'))
-        detail['ok'] = qbit_ok and hook_ok
+        detail['ok'] = sync_ok and hook_ok
         detail['listen_port'] = last.get('listen_port')
         detail['error'] = last.get('error') or (hook.get('error') or '')
         if detail['ok']:

--- a/app/rotation_pools.py
+++ b/app/rotation_pools.py
@@ -405,6 +405,11 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
     from_server   = list(_cur_filters.values())[0].split(',')[0].strip() if _cur_filters else None
     pre_deps      = list_network_dependents_for_recreate(container)
 
+    # Capture the outgoing VPN provider so port-forward rules can follow a
+    # provider change (multi-provider pools rotate across WireGuard profiles)
+    from .port_forwarding import get_gluetun_provider as _pf_provider
+    old_provider = _pf_provider(container)
+
     # Capture current public IP before the switch
     try:
         from_ipv4, from_ipv6 = get_public_ips(proxy_host, proxy_port, proxy_user, proxy_pass)
@@ -469,6 +474,22 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
             'recreated %d network dependent(s) anyway: %s',
             pool_id, wait_secs, len(restarted), ', '.join(restarted) or 'none',
         )
+
+    # ── Port forwards: follow a provider change across the rotation ─────────
+    try:
+        from .port_forwarding import apply_after_provider_change
+        new_provider = _pf_provider(container)
+        pf_result = apply_after_provider_change(
+            old_provider, new_provider, reason='pool_rotation',
+        )
+        if pf_result.get('provider_changed') and not pf_result.get('skipped_reason'):
+            logger.info(
+                'Pool rotation [%d]: port forwards %s -> %s: applied %s/%s, ok=%s',
+                pool_id, old_provider or '?', new_provider or '?',
+                pf_result.get('applied', 0), pf_result.get('rules', 0), pf_result.get('ok'),
+            )
+    except Exception as _pf_exc:
+        logger.warning('Pool rotation [%d]: port forward apply failed: %s', pool_id, _pf_exc)
 
     # Record switch — IPs/to_mbps added via UPDATE once the bench completes
     switch_id: int | None = None

--- a/app/routes.py
+++ b/app/routes.py
@@ -2898,7 +2898,10 @@ def api_tracker_enabled(tracker_id: int):
 @bp.route('/api/port-forwards/<int:port_forward_id>/sync-qbittorrent', methods=['POST'])
 @login_required
 def api_port_forward_sync_qbittorrent(port_forward_id: int):
-    result = sync_qbit_listen_port(port_forward_id)
+    # Dispatches on the linked client type (qBittorrent or rTorrent);
+    # historical route name kept for UI compatibility.
+    from .port_forwarding import sync_client_listen_port
+    result = sync_client_listen_port(port_forward_id)
     return jsonify(result), (200 if result.get('ok') else 400)
 
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -2274,6 +2274,52 @@ def _apply_port_forwards_after_provider_change(
     return result
 
 
+def _check_port_forward_renewal(app) -> None:
+    """Periodic watchdog: detect a native forwarded-port renewal without restart.
+
+    Gluetun can renew the forwarded port mid-session (e.g. NAT-PMP renewal)
+    without the container restarting — so no Docker event fires.  Every run,
+    compare the current /v1/portforward value to the last applied port of the
+    active native rules; on mismatch, re-apply the provider rules.
+    """
+    from .database import get_setting
+    if get_setting('port_forward_enabled', '0') != '1':
+        return
+    if get_setting('port_forward_auto_sync', '0') != '1':
+        return
+    if get_setting('benchmark_running', '0') == '1':
+        return   # clients may be paused; the post-benchmark switch re-applies anyway
+
+    from .port_forwarding import (
+        get_gluetun_provider, list_active_provider_forwards, read_gluetun_native_ports,
+    )
+    container = app.config['GLUETUN_CONTAINER']
+    provider = get_gluetun_provider(container)
+    if not provider:
+        return
+    native_rules = [
+        pf for pf in list_active_provider_forwards(provider)
+        if (pf.get('mode') or 'manual') == 'native'
+    ]
+    if not native_rules:
+        return
+    native = read_gluetun_native_ports()
+    ports = native.get('ports') or []
+    if not native.get('ok') or not ports:
+        logger.debug('PF renewal check: native port unavailable (%s)', native.get('error'))
+        return
+    current = int(ports[0])
+    stale = [pf for pf in native_rules if int(pf.get('last_applied_port') or 0) != current]
+    if not stale:
+        return
+    logger.info(
+        'PF renewal check: native port is now %d but %d rule(s) last applied a different '
+        'port — re-applying provider %s', current, len(stale), provider,
+    )
+    from .port_forwarding import apply_provider_port_forwards
+    apply_provider_port_forwards(provider, reason='port_renewal')
+
+
 def _apply_port_forwards_for_current_provider(container: str, reason: str) -> dict:
     from .database import get_setting
     if get_setting('port_forward_enabled', '0') != '1':
@@ -2887,6 +2933,14 @@ def start_scheduler(app):
         trigger=IntervalTrigger(minutes=5),
         args=[app],
         id='pool_rotation_check',
+        replace_existing=True,
+        misfire_grace_time=120,
+    )
+    _scheduler.add_job(
+        _check_port_forward_renewal,
+        trigger=IntervalTrigger(minutes=5),
+        args=[app],
+        id='pf_renewal_check',
         replace_existing=True,
         misfire_grace_time=120,
     )

--- a/app/templates/dash_test.html
+++ b/app/templates/dash_test.html
@@ -78,7 +78,7 @@
 </style>
 <div class="proposal-head">
   <div>
-    <div class="proposal-kicker">Proposition Codex</div>
+    <div class="proposal-kicker">Aperçu expérimental</div>
     <h5 class="proposal-title"><i class="bi bi-speedometer2"></i> Console VPN</h5>
     <div class="proposal-subtitle">Un cockpit compact : etat immediat, serveur actif, prochaine action, puis donnees qui aident a decider.</div>
   </div>

--- a/app/templates/history_test.html
+++ b/app/templates/history_test.html
@@ -26,7 +26,7 @@
 </style>
 <div class="proposal-head">
   <div>
-    <div class="proposal-kicker">Proposition Codex</div>
+    <div class="proposal-kicker">Aperçu expérimental</div>
     <h5 class="proposal-title"><i class="bi bi-graph-up"></i> Historique analytique</h5>
     <div class="proposal-subtitle">Une page d'enquete : tendances en haut, filtres juste avant les donnees, table detaillee pour verifier.</div>
   </div>

--- a/app/templates/servers_test.html
+++ b/app/templates/servers_test.html
@@ -47,7 +47,7 @@
 </style>
 <div class="proposal-head">
   <div>
-    <div class="proposal-kicker">Proposition Codex</div>
+    <div class="proposal-kicker">Aperçu expérimental</div>
     <h5 class="proposal-title"><i class="bi bi-hdd-network"></i> Selection serveur</h5>
     <div class="proposal-subtitle">Une page de pilotage : les serveurs sont comparables vite, les signaux faibles restent visibles, les actions restent a portee.</div>
   </div>

--- a/app/templates/switches_test.html
+++ b/app/templates/switches_test.html
@@ -113,7 +113,7 @@
 
 <div class="proposal-head">
   <div>
-    <div class="proposal-kicker">Proposition Codex</div>
+    <div class="proposal-kicker">Aperçu expérimental</div>
     <h5 class="proposal-title"><i class="bi bi-arrow-left-right"></i> Journal des bascules</h5>
     <div class="proposal-subtitle">Une timeline operationnelle : origine, destination, gain reel, raison et resultat restent lisibles d'un coup d'oeil.</div>
   </div>

--- a/app/torrent_trackers.py
+++ b/app/torrent_trackers.py
@@ -253,17 +253,29 @@ def _qbit_trackers(client: dict, timeout: float = 8.0) -> list[TrackerHit]:
     return hits
 
 
-def _rtorrent_trackers(client: dict, timeout: float = 8.0) -> list[TrackerHit]:
+def rtorrent_proxy(client: dict, timeout: float = 8.0) -> 'xmlrpc.client.ServerProxy':
+    """Build an XML-RPC proxy for an rTorrent/ruTorrent client config.
+
+    Applies HTTP basic-auth from the stored credentials and defaults the
+    path to /RPC2 when the base URL has none.  Shared by tracker discovery
+    and port-forward synchronisation.
+    """
     url = client['base_url'].rstrip('/')
-    transport = None
+    parts = urlsplit(url)
+    netloc = parts.netloc
     if client.get('username') or client.get('password'):
         from urllib.parse import quote
-        parts = urlsplit(url)
-        userinfo = f"{quote(client.get('username', ''), safe='')}:{quote(client.get('password', ''), safe='')}@"
-        netloc = userinfo + parts.netloc
-        url = urlunsplit((parts.scheme, netloc, parts.path or '/RPC2', parts.query, parts.fragment))
+        netloc = (
+            f"{quote(client.get('username', ''), safe='')}:"
+            f"{quote(client.get('password', ''), safe='')}@" + parts.netloc
+        )
+    url = urlunsplit((parts.scheme, netloc, parts.path or '/RPC2', parts.query, parts.fragment))
     transport = _TimeoutSafeTransport(timeout) if url.startswith('https://') else _TimeoutTransport(timeout)
-    proxy = xmlrpc.client.ServerProxy(url, allow_none=True, use_builtin_types=True, transport=transport)
+    return xmlrpc.client.ServerProxy(url, allow_none=True, use_builtin_types=True, transport=transport)
+
+
+def _rtorrent_trackers(client: dict, timeout: float = 8.0) -> list[TrackerHit]:
+    proxy = rtorrent_proxy(client, timeout=timeout)
     rows = proxy.d.multicall2('', 'main', 'd.hash=', 'd.name=')
     hits: list[TrackerHit] = []
     for row in rows or []:


### PR DESCRIPTION
## Résumé

- ajoute la synchronisation du port d’écoute rTorrent via XML-RPC, avec relecture de contrôle ;
- surveille toutes les cinq minutes les renouvellements de port natif Gluetun effectués sans redémarrage ;
- applique les règles de port forwarding lors des rotations de pool entre fournisseurs ;
- complète la documentation française et anglaise ;
- exclut les notes privées, caches Python et données d’exécution du suivi Git ;
- neutralise les anciens libellés internes des pages d’aperçu.

## Vérifications

- compilation Python de `app` et `sidecar` ;
- test de non-duplication des variables de l’override Compose ;
- validation YAML du compose et des modèles d’issues ;
- contrôle `git diff --check` ;
- recherche de traces internes explicites.

## Remarque

La synchronisation rTorrent reste indiquée comme bêta : elle suit l’API XML-RPC documentée mais n’a pas encore été validée sur une instance rTorrent réelle. Le hook `on_port_change` reste disponible en solution de repli.