### PR TITLE
Retirer le débit de la fenêtre optimale sur l'accueil

### DIFF
--- a/app/templates/dash_test.html
+++ b/app/templates/dash_test.html
@@ -139,7 +139,6 @@
           <div style="font-size:.72rem;color:var(--muted)">Fenêtre optimale de benchmark</div>
           <div>
             <span class="text-success fw-semibold" style="font-size:.9rem">{{ '%02d'|format(adaptive_stats.best_hour) }}h</span>
-            <span class="text-muted ms-1" style="font-size:.72rem">· {{ adaptive_stats.hours[adaptive_stats.best_hour].avg_dl }} Mbps</span>
           </div>
         </div>
       </div>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -204,7 +204,6 @@
           <div style="font-size:.72rem;color:var(--muted)">{{ t.dash_optimal_window }}</div>
           <div>
             <span class="text-success fw-semibold" style="font-size:.9rem">{{ '%02d'|format(adaptive_stats.best_hour) }}h</span>
-            <span class="text-muted ms-1" style="font-size:.72rem">· {{ adaptive_stats.hours[adaptive_stats.best_hour].avg_dl }} Mbps</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Résumé : retire le débit descendant moyen de l'encart Fenêtre optimale de benchmark et conserve uniquement l'heure optimale. La variante interne du dashboard est également corrigée. Validation : templates Jinja compilés, test unitaire existant validé et git diff --check sans erreur.