### PR TITLE
Corriger l’observation DNS avec docker-socket-proxy

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -130,7 +130,7 @@ Companion separates two pieces of information:
 
 When a private tunnel address appears to belong to the VPN provider, the UI remains cautious: `Probable intermediary: AirVPN VPN provider DNS (10.x.x.x)`. No local software such as AdGuard Home or Pi-hole is assumed or required.
 
-Universal detection uses the free [bash.ws](https://bash.ws/dnsleak) service: Companion requests an identifier, triggers ten unique resolutions from inside the Gluetun container, then retrieves the observed resolver IPs, ASNs and countries. Results are cached for six hours to limit requests. This operation discloses the VPN IP and test DNS queries to the third-party service, but no Companion identifier or user-browsed domain.
+Universal detection uses the free [bash.ws](https://bash.ws/dnsleak) service: a temporary sidecar sharing Gluetun's network requests an identifier, triggers ten unique resolutions, then retrieves the observed resolver IPs, ASNs and countries. No `docker exec` or additional Docker socket access is required. Results are cached for six hours to limit requests. This operation discloses the VPN IP and test DNS queries to the third-party service, but no Companion identifier or user-browsed domain.
 
 The **VPN Status** card displays the intermediary and observed operators. In tables, only DNS latency remains visible; details are provided in a tooltip. The state is also exposed by `GET /api/v1/status` under `dns_path` (`intermediary`, `resolvers`, `observed_summary`, `tested_at`).
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Companion distingue deux informations :
 
 Lorsqu'une adresse privée du tunnel semble appartenir au fournisseur VPN, l'interface reste prudente : `Intermédiaire probable : DNS du fournisseur VPN AirVPN (10.x.x.x)`. Aucun logiciel local comme AdGuard Home ou Pi-hole n'est supposé ou requis.
 
-La détection universelle utilise le service gratuit [bash.ws](https://bash.ws/dnsleak) : Companion demande un identifiant, provoque dix résolutions uniques depuis le conteneur Gluetun, puis récupère les IP, ASN et pays des résolveurs observés. Le résultat est conservé six heures pour limiter les requêtes. Cette opération communique au service tiers l'IP VPN et les requêtes DNS de test, mais aucun identifiant Companion ni domaine consulté par l'utilisateur.
+La détection universelle utilise le service gratuit [bash.ws](https://bash.ws/dnsleak) : un sidecar temporaire partageant le réseau de Gluetun demande un identifiant, provoque dix résolutions uniques, puis récupère les IP, ASN et pays des résolveurs observés. Aucun `docker exec` ni accès supplémentaire au socket Docker n'est requis. Le résultat est conservé six heures pour limiter les requêtes. Cette opération communique au service tiers l'IP VPN et les requêtes DNS de test, mais aucun identifiant Companion ni domaine consulté par l'utilisateur.
 
 L'encart **Statut VPN** affiche l'intermédiaire et les opérateurs observés. Dans les tableaux, seule la latence DNS reste visible ; le détail est disponible en infobulle. L'état est aussi exposé par `GET /api/v1/status` sous la clé `dns_path` (`intermediary`, `resolvers`, `observed_summary`, `tested_at`).
 

--- a/app/dns_path.py
+++ b/app/dns_path.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import docker
-import requests
 
 from .database import get_setting, set_setting
 from .gluetun import get_container_env
@@ -25,8 +24,7 @@ _CACHE_LOCK = threading.Lock()
 _REFRESH_LOCK = threading.Lock()
 _CACHE_TTL = 60.0
 _OBSERVATION_TTL = 6 * 3600
-_BASH_WS_ID_URL = 'https://bash.ws/id'
-_BASH_WS_RESULT_URL = 'https://bash.ws/dnsleak/test/{test_id}?json'
+_DNS_OBSERVER_NAME = 'gluetun-companion-dns-observer'
 
 _PUBLIC_DNS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ('Cloudflare', ('1.1.1.1', '1.0.0.1', '2606:4700:4700::1111',
@@ -146,18 +144,59 @@ def _observation_is_stale(observation: dict) -> bool:
     return time.time() - float(observation.get('timestamp') or 0) >= ttl
 
 
-def _trigger_dns_queries(container_name: str, test_id: str) -> None:
-    container = docker.from_env().containers.get(container_name)
-    for index in range(10):
-        hostname = f'{index}.{test_id}.bash.ws'
-        command = (
-            f'ping -c 1 -W 2 {hostname} >/dev/null 2>&1 || '
-            f'getent hosts {hostname} >/dev/null 2>&1 || '
-            f'wget -q -T 3 -O /dev/null http://{hostname} >/dev/null 2>&1'
+def _remove_observer(client) -> None:
+    try:
+        client.containers.get(_DNS_OBSERVER_NAME).remove(force=True)
+    except docker.errors.NotFound:
+        pass
+
+
+def _run_observation_sidecar(container_name: str) -> list[dict]:
+    """Run the complete bash.ws test through Gluetun without Docker exec."""
+    client = docker.from_env()
+    _remove_observer(client)
+    image = get_setting('sidecar_image', 'ghcr.io/aerya/gluetun-companion-sidecar:latest')
+    command = r'''
+set -eu
+test_id="$(curl -fsSL --max-time 10 https://bash.ws/id)"
+case "$test_id" in *[!A-Za-z0-9_-]*|'') exit 2 ;; esac
+for index in 0 1 2 3 4 5 6 7 8 9; do
+  dig +time=2 +tries=1 "${index}.${test_id}.bash.ws" >/dev/null 2>&1 || true
+done
+curl -fsSL --max-time 15 "https://bash.ws/dnsleak/test/${test_id}?json"
+'''.strip()
+    container = None
+    try:
+        container = client.containers.run(
+            image=image,
+            name=_DNS_OBSERVER_NAME,
+            network_mode=f'container:{container_name}',
+            command=['sh', '-c', command],
+            detach=True,
+            remove=False,
         )
-        result = container.exec_run(['sh', '-c', command])
-        if result.exit_code not in (0, 1):
-            logger.debug('DNS observation probe failed for %s: exit=%s', hostname, result.exit_code)
+        deadline = time.time() + 35
+        while time.time() < deadline:
+            container.reload()
+            if container.status in ('exited', 'dead'):
+                break
+            time.sleep(0.5)
+        else:
+            raise TimeoutError('DNS observation sidecar timed out')
+        exit_code = int(container.attrs.get('State', {}).get('ExitCode', 1))
+        output = container.logs(stdout=True, stderr=True).decode('utf-8', errors='replace').strip()
+        if exit_code != 0:
+            raise RuntimeError(f'DNS observation sidecar exited with code {exit_code}: {output}')
+        payload = json.loads(output)
+        if not isinstance(payload, list):
+            raise RuntimeError('bash.ws returned an invalid DNS observation payload')
+        return payload
+    finally:
+        if container is not None:
+            try:
+                container.remove(force=True)
+            except Exception as exc:
+                logger.debug('Could not remove DNS observation sidecar: %s', exc)
 
 
 def refresh_observed_resolvers(container_name: str) -> dict:
@@ -165,13 +204,7 @@ def refresh_observed_resolvers(container_name: str) -> dict:
     if not _REFRESH_LOCK.acquire(blocking=False):
         return _load_observation()
     try:
-        test_id = requests.get(_BASH_WS_ID_URL, timeout=8).text.strip()
-        if not test_id or not re.fullmatch(r'[A-Za-z0-9_-]+', test_id):
-            raise RuntimeError('bash.ws returned an invalid test identifier')
-        _trigger_dns_queries(container_name, test_id)
-        response = requests.get(_BASH_WS_RESULT_URL.format(test_id=test_id), timeout=10)
-        response.raise_for_status()
-        payload = response.json()
+        payload = _run_observation_sidecar(container_name)
         resolvers: list[dict[str, str]] = []
         seen: set[str] = set()
         for item in payload if isinstance(payload, list) else []:

--- a/tests/test_dns_path.py
+++ b/tests/test_dns_path.py
@@ -1,8 +1,13 @@
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from app.dns_path import _build_dns_status, _intermediary, _provider_name
+from app.dns_path import (
+    _build_dns_status,
+    _intermediary,
+    _provider_name,
+    _run_observation_sidecar,
+)
 
 
 class DnsPathTest(unittest.TestCase):
@@ -29,6 +34,25 @@ class DnsPathTest(unittest.TestCase):
         }, 'fr')
         self.assertTrue(result['probable'])
         self.assertIn('AirVPN', result['label'])
+
+    @patch('app.dns_path.get_setting', return_value='test-sidecar:latest')
+    @patch('app.dns_path.docker.from_env')
+    def test_observation_uses_temporary_sidecar_in_gluetun_network(self, from_env, _setting):
+        client = from_env.return_value
+        client.containers.get.side_effect = __import__('docker').errors.NotFound('missing')
+        observer = MagicMock()
+        observer.status = 'exited'
+        observer.attrs = {'State': {'ExitCode': 0}}
+        observer.logs.return_value = b'[{"type":"dns","ip":"1.1.1.1"}]'
+        client.containers.run.return_value = observer
+
+        payload = _run_observation_sidecar('gluetun-airvpn')
+
+        self.assertEqual(payload[0]['ip'], '1.1.1.1')
+        kwargs = client.containers.run.call_args.kwargs
+        self.assertEqual(kwargs['network_mode'], 'container:gluetun-airvpn')
+        self.assertEqual(kwargs['image'], 'test-sidecar:latest')
+        observer.remove.assert_called_once_with(force=True)
 
     @patch('app.dns_path._refresh_in_background')
     @patch('app.dns_path.get_setting')


### PR DESCRIPTION
## Problème

L’observation des résolveurs DNS utilisait `docker exec` dans le conteneur Gluetun. Cet endpoint est volontairement bloqué par la configuration sécurisée recommandée de `docker-socket-proxy`, ce qui produisait une erreur HTTP 403.

## Correction

- exécute le test bash.ws dans un sidecar temporaire partageant le réseau de Gluetun ;
- fait passer l’identifiant, les requêtes DNS et la récupération JSON par le tunnel VPN ;
- supprime tout appel à `docker exec` ;
- nettoie automatiquement le sidecar après le test ;
- conserve les permissions actuelles du proxy Docker, sans modification du compose ;
- met à jour les README français et anglais.

## Validation

- tests unitaires réussis ;
- compilation Python réussie ;
- images Docker et smoke test validés.
