### PR TITLE
Corriger la gestion du port dynamique ProtonVPN

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -514,6 +514,18 @@ The **Sync** button updates the linked client's listen port: qBittorrent through
 
 To enable Gluetun native support, configure Gluetun with [`VPN_PORT_FORWARDING=on`](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/port-forwarding.md) and expose its [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). In Companion, set the URL, for example `http://host.docker.internal:8967` when Docker publishes `8967:8000`. If Gluetun uses `apikey` authentication, also enter the `X-API-Key` value. Companion uses `/v1/portforward` as the primary source; the historical Gluetun status file is not used as the preferred source because Gluetun documents it as eventually deprecated.
 
+#### ProtonVPN and qBittorrent
+
+ProtonVPN assigns a random NAT-PMP port which may change on every connection or renewal. Do not enter a fixed port or publish that port in the Docker Compose file. Configure a rule using provider `ProtonVPN`, **Gluetun native** mode, and the relevant qBittorrent client. Companion:
+
+1. reads the current port from `GET /v1/portforward`;
+2. sends it to qBittorrent through `/api/v2/app/setPreferences`;
+3. reads qBittorrent preferences back to confirm the change;
+4. checks every 5 minutes whether Gluetun renewed the port and injects the new value when needed;
+5. repeats after a Gluetun reconnect or a switch to ProtonVPN.
+
+Add `VPN_PORT_FORWARDING=on` to Gluetun. With ProtonVPN over **OpenVPN**, the OpenVPN username must also carry the `+pmp` suffix. ProtonVPN over **WireGuard** does not use this suffix. Gluetun native integrations open the dynamic port on the VPN side themselves, so `FIREWALL_VPN_INPUT_PORTS`, `FIREWALL_INPUT_PORTS`, and a static Docker port mapping are not required for this port.
+
 For AirVPN, Companion does not create the port in the AirVPN panel. The expected flow is:
 
 1. reserve the port in the AirVPN panel;

--- a/README.md
+++ b/README.md
@@ -514,6 +514,18 @@ Le bouton **Synchroniser** met à jour le port d'écoute du client lié : qBitto
 
 Pour activer le support natif Gluetun, configurez Gluetun avec [`VPN_PORT_FORWARDING=on`](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/port-forwarding.md) et exposez son [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). Dans Companion, renseignez l'URL, par exemple `http://host.docker.internal:8967` si le port Docker `8967:8000` est publié. Si Gluetun utilise une auth `apikey`, renseignez aussi la valeur `X-API-Key`. Companion utilise `/v1/portforward` comme source principale ; le fichier de statut Gluetun historique n'est pas utilisé comme source prioritaire, car il est annoncé comme déprécié à terme par Gluetun.
 
+#### ProtonVPN et qBittorrent
+
+ProtonVPN attribue un port NAT-PMP aléatoire, susceptible de changer à chaque connexion ou renouvellement. Il ne faut donc ni saisir un port fixe, ni publier ce port dans le Compose Docker. Configurez une règle avec le fournisseur `ProtonVPN`, le mode **Natif Gluetun** et le client qBittorrent concerné. Companion :
+
+1. lit le port courant dans `GET /v1/portforward` ;
+2. l'envoie à qBittorrent via `/api/v2/app/setPreferences` ;
+3. relit les préférences qBittorrent pour confirmer l'application ;
+4. vérifie toutes les 5 minutes si Gluetun a renouvelé le port et le réinjecte si nécessaire ;
+5. recommence après une reconnexion Gluetun ou une bascule vers ProtonVPN.
+
+Côté Gluetun, ajoutez `VPN_PORT_FORWARDING=on`. Avec ProtonVPN en **OpenVPN**, le nom d'utilisateur OpenVPN doit aussi porter le suffixe `+pmp`. Avec ProtonVPN en **WireGuard**, ce suffixe n'est pas utilisé. Les intégrations natives de Gluetun ouvrent elles-mêmes le port dynamique côté VPN : `FIREWALL_VPN_INPUT_PORTS`, `FIREWALL_INPUT_PORTS` et un mapping Docker statique ne sont pas requis pour ce port.
+
 Pour AirVPN, Companion ne crée pas le port sur le panel AirVPN. Le flux attendu est :
 
 1. réserver le port dans le panel AirVPN ;

--- a/app/port_forwarding.py
+++ b/app/port_forwarding.py
@@ -568,10 +568,20 @@ def apply_after_provider_change(old_provider: str, new_provider: str, *, reason:
     return result
 
 
-def inspect_port_forward(pf: dict, gluetun_container: str) -> dict:
+def inspect_port_forward(
+    pf: dict,
+    gluetun_container: str,
+    native_status: dict | None = None,
+) -> dict:
     item = dict(pf)
     protocols = _clean_protocols(item.get('protocols')).split(',')
-    port = int(item.get('port') or 0)
+    native_mode = (item.get('mode') or 'manual') == 'native'
+    if native_mode:
+        native_status = native_status or read_gluetun_native_ports()
+        native_ports = native_status.get('ports') or []
+        port = int(native_ports[0]) if native_ports else 0
+    else:
+        port = int(item.get('port') or 0)
 
     env = {}
     env_error = ''
@@ -582,7 +592,10 @@ def inspect_port_forward(pf: dict, gluetun_container: str) -> dict:
 
     fw_vpn_ports = _parse_port_list(env.get('FIREWALL_VPN_INPUT_PORTS', '')) if env else set()
     fw_input_ports = _parse_port_list(env.get('FIREWALL_INPUT_PORTS', '')) if env else set()
-    docker_ports = _docker_published_ports(gluetun_container, port, protocols)
+    docker_ports = (
+        {proto: None for proto in protocols}
+        if native_mode else _docker_published_ports(gluetun_container, port, protocols)
+    )
 
     client_status = {'state': 'unknown', 'label': 'non lié'}
     client_listen_port = None
@@ -596,9 +609,21 @@ def inspect_port_forward(pf: dict, gluetun_container: str) -> dict:
             client_status = {'state': 'unknown', 'label': 'lecture non supportée'}
 
     item['protocol_list'] = protocols
-    item['gluetun_vpn_input'] = _status(port in fw_vpn_ports if env else None)
-    item['gluetun_input'] = _status(port in fw_input_ports if env else None)
-    item['docker_ports'] = {proto: _status(docker_ports.get(proto), proto.upper(), proto.upper()) for proto in protocols}
+    item['effective_port'] = port or None
+    if native_mode:
+        native_ok = bool(native_status and native_status.get('ok') and port)
+        item['gluetun_vpn_input'] = _status(native_ok, 'Natif OK', 'indisponible')
+        item['gluetun_input'] = {'state': 'ok', 'label': 'géré par Gluetun'}
+        item['docker_ports'] = {
+            proto: {'state': 'ok', 'label': 'non requis'} for proto in protocols
+        }
+    else:
+        item['gluetun_vpn_input'] = _status(port in fw_vpn_ports if env else None)
+        item['gluetun_input'] = _status(port in fw_input_ports if env else None)
+        item['docker_ports'] = {
+            proto: _status(docker_ports.get(proto), proto.upper(), proto.upper())
+            for proto in protocols
+        }
     item['client_status'] = client_status
     item['client_listen_port'] = client_listen_port
     item['client_error'] = client_error
@@ -624,4 +649,10 @@ def inspect_port_forward(pf: dict, gluetun_container: str) -> dict:
 
 
 def inspect_port_forwards(gluetun_container: str) -> list[dict]:
-    return [inspect_port_forward(pf, gluetun_container) for pf in list_port_forwards()]
+    forwards = list_port_forwards()
+    native_status = (
+        read_gluetun_native_ports()
+        if any((pf.get('mode') or 'manual') == 'native' for pf in forwards)
+        else None
+    )
+    return [inspect_port_forward(pf, gluetun_container, native_status) for pf in forwards]

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -2306,6 +2306,11 @@
       </div>
     </form>
 
+    <div class="alert alert-info py-2 px-3 mb-3 small">
+      <strong>ProtonVPN :</strong>
+      {{ 'utilisez une règle ProtonVPN en mode Natif Gluetun, sans port statique. Gluetun obtient le port NAT-PMP aléatoire ; Companion le lit via /v1/portforward, l’injecte dans qBittorrent et surveille ses renouvellements toutes les 5 minutes. Activez VPN_PORT_FORWARDING=on dans Gluetun. En OpenVPN, ajoutez aussi +pmp à l’identifiant Proton ; en WireGuard, +pmp n’est pas utilisé.' if session.get('lang','fr') == 'fr' else 'use a ProtonVPN rule in Gluetun native mode, without a static port. Gluetun obtains the random NAT-PMP port; Companion reads it from /v1/portforward, injects it into qBittorrent, and monitors renewals every 5 minutes. Enable VPN_PORT_FORWARDING=on in Gluetun. With OpenVPN, also append +pmp to the Proton username; WireGuard does not use +pmp.' }}
+    </div>
+
     {% if port_forwards %}
     <div class="d-flex flex-column gap-2 mb-3">
       {% for pf in port_forwards %}
@@ -2313,7 +2318,7 @@
         <summary class="d-flex flex-wrap align-items-center gap-2" style="cursor:pointer">
           <span class="badge {{ 'bg-success' if pf.enabled else 'bg-secondary' }}">{{ 'ON' if pf.enabled else 'OFF' }}</span>
           <strong>{{ pf.name }}</strong>
-          <code>{{ pf.port }}/{{ pf.protocols }}</code>
+          <code>{{ (pf.effective_port or '—') if pf.mode == 'native' else pf.port }}/{{ pf.protocols }}</code>
           <span class="badge {{ 'bg-success' if pf.overall_state == 'ok' else ('bg-danger' if pf.overall_state == 'bad' else 'bg-secondary') }}">{{ pf.overall_label }}</span>
           <span class="text-muted small">{{ pf.provider }} · {{ 'Natif Gluetun' if pf.mode == 'native' and session.get('lang','fr') == 'fr' else ('Gluetun native' if pf.mode == 'native' else ('Manuel' if session.get('lang','fr') == 'fr' else 'Manual')) }}</span>
           {% if pf.client_name %}

--- a/tests/test_port_forwarding.py
+++ b/tests/test_port_forwarding.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.port_forwarding import (
+    _extract_ports,
+    inspect_port_forward,
+    sync_qbit_listen_port,
+)
+
+
+class ProtonPortForwardingTest(unittest.TestCase):
+    def test_gluetun_control_server_port_payload(self):
+        self.assertEqual(_extract_ports({'port': 5914}), [5914])
+
+    @patch('app.port_forwarding._docker_published_ports')
+    @patch('app.port_forwarding._container_env', return_value={
+        'VPN_SERVICE_PROVIDER': 'protonvpn',
+        'VPN_PORT_FORWARDING': 'on',
+    })
+    def test_native_rule_uses_dynamic_port_without_static_mappings(self, _env, docker_ports):
+        rule = {
+            'id': 1,
+            'name': 'ProtonVPN qBittorrent',
+            'provider': 'protonvpn',
+            'mode': 'native',
+            'port': 0,
+            'protocols': 'tcp,udp',
+            'torrent_client_id': None,
+        }
+        result = inspect_port_forward(
+            rule,
+            'gluetun-protonvpn',
+            {'ok': True, 'ports': [5914], 'error': ''},
+        )
+        self.assertEqual(result['effective_port'], 5914)
+        self.assertEqual(result['gluetun_vpn_input']['state'], 'ok')
+        self.assertEqual(result['gluetun_input']['state'], 'ok')
+        self.assertTrue(all(item['state'] == 'ok' for item in result['docker_ports'].values()))
+        docker_ports.assert_not_called()
+
+    @patch('app.port_forwarding._set_last_applied_port')
+    @patch('app.port_forwarding._qbit_listen_port', return_value=(5914, ''))
+    @patch('app.port_forwarding._qbit_session')
+    @patch('app.port_forwarding.get_torrent_client', return_value={
+        'id': 4,
+        'client_type': 'qbittorrent',
+        'base_url': 'http://qbittorrent:8080',
+    })
+    @patch('app.port_forwarding.get_port_forward', return_value={
+        'id': 7,
+        'provider': 'protonvpn',
+        'mode': 'native',
+        'port': 0,
+        'torrent_client_id': 4,
+    })
+    def test_dynamic_proton_port_is_injected_into_qbittorrent(
+        self, _rule, _client, qbit_session, _listen_port, remember_port,
+    ):
+        response = MagicMock(status_code=200)
+        qbit_session.return_value.post.return_value = response
+
+        result = sync_qbit_listen_port(7, port_override=5914)
+
+        self.assertTrue(result['ok'])
+        self.assertEqual(result['listen_port'], 5914)
+        post = qbit_session.return_value.post
+        self.assertIn('setPreferences', post.call_args.args[0])
+        self.assertIn('5914', post.call_args.kwargs['data']['json'])
+        remember_port.assert_called_once_with(7, 5914)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problème

ProtonVPN attribue un port NAT-PMP aléatoire qui peut changer à chaque connexion ou renouvellement. L’injection vers qBittorrent existait déjà, mais l’interface contrôlait encore le port statique enregistré dans la règle, souvent égal à zéro, et exigeait à tort des mappings Docker et firewall statiques.

## Correction

- utilise le port dynamique réellement retourné par `GET /v1/portforward` pour les règles natives ;
- injecte ce port dans qBittorrent via `/api/v2/app/setPreferences` et confirme la valeur par relecture ;
- conserve la surveillance toutes les cinq minutes et la réapplication après reconnexion ou bascule ;
- n’exige plus de mapping Docker, `FIREWALL_INPUT_PORTS` ou `FIREWALL_VPN_INPUT_PORTS` statique pour une intégration native Gluetun ;
- affiche le port effectif dans la WebUI ;
- ajoute un guide ProtonVPN explicite dans la WebUI et les README français et anglais ;
- précise `VPN_PORT_FORWARDING=on`, le suffixe OpenVPN `+pmp` et la différence avec WireGuard.

## Validation

- 13 tests unitaires réussis ;
- test dédié de la réponse Gluetun `{"port": 5914}` ;
- test de l’injection du port 5914 dans qBittorrent ;
- test confirmant l’absence de contrôle statique Docker pour une règle native ;
- compilation Python et des 13 templates Jinja ;
- audit UTF-8 strict.
