### PR TITLE
Gérer le filtrage DNS malveillant de Gluetun

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -460,6 +460,8 @@ In **Settings → Measure → Containers to pause during benchmark**: list of co
 
 In **Settings → Trackers**, Companion can verify whether the trackers actually used by your torrents are reachable from the VPN server being tested or selected. The goal is not to perform a full real announce for every torrent, but to verify useful connectivity with four levels:
 
+Gluetun enables `BLOCK_MALICIOUS=on` by default. Some announce URLs may therefore be blocked by its DNS lists even when the tracker is available. Under **Settings → Trackers → Gluetun DNS filtering**, Companion can keep this protection enabled while allowing specific domains through `DNS_UNBLOCK_HOSTNAMES`, or disable `BLOCK_MALICIOUS` entirely as a last resort. The setting is written to `docker-compose.override.yml`, applied immediately by recreating Gluetun, and preserved across subsequent switches. Disabling it globally reduces DNS protection for every container sharing Gluetun's network; a targeted exception is recommended.
+
 1. **DNS** — the tracker domain can be resolved.
 2. **Port** — the TCP/UDP tracker port responds.
 3. **Tracker endpoint** — the `/announce` URL or UDP tracker handshake responds. HTTP `400`, `401`, `403` or `invalid request` responses can still count as reachable: the tracker rejected the test request, but the endpoint is accessible.

--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ Dans **Paramètres → Mesurer → Containers à stopper pendant le benchmark** 
 
 Dans **Paramètres → Trackers**, Companion peut vérifier si les trackers réellement utilisés par vos torrents sont accessibles depuis le serveur VPN testé ou sélectionné. L'objectif n'est pas de faire un vrai announce complet pour chaque torrent, mais de vérifier la connectivité utile avec quatre niveaux :
 
+Gluetun active `BLOCK_MALICIOUS=on` par défaut. Certaines URL d'annonce peuvent donc être bloquées par ses listes DNS même si le tracker est disponible. Dans **Paramètres → Trackers → Filtrage DNS Gluetun**, Companion permet de conserver cette protection tout en autorisant des domaines précis via `DNS_UNBLOCK_HOSTNAMES`, ou de désactiver entièrement `BLOCK_MALICIOUS` en dernier recours. Le réglage est écrit dans `docker-compose.override.yml`, appliqué immédiatement en recréant Gluetun et conservé lors des bascules suivantes. La désactivation globale réduit la protection DNS de tous les containers partageant le réseau de Gluetun ; l'exception ciblée est recommandée.
+
 1. **DNS** — le domaine du tracker peut être résolu.
 2. **Port** — le port TCP/UDP du tracker répond.
 3. **Endpoint tracker** — l'URL `/announce` ou le handshake UDP tracker répond. Une réponse HTTP `400`, `401`, `403` ou `invalid request` peut être considérée comme joignable : le tracker refuse la requête de test, mais il est bien accessible.

--- a/app/database.py
+++ b/app/database.py
@@ -361,6 +361,8 @@ def init_db(db_path: str):
                 ('tracker_check_threshold_pct','80'),
                 ('tracker_check_timeout_secs', '3'),
                 ('tracker_check_concurrency',  '12'),
+                ('dns_block_malicious',        '1'),
+                ('dns_unblock_hostnames',      ''),
                 ('port_forward_enabled',       '0'),
                 ('port_forward_auto_sync',     '1'),
                 ('port_forward_gluetun_api_url', 'http://host.docker.internal:8000'),

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -22,6 +22,8 @@ from urllib.parse import quote
 import docker
 import requests
 
+from .database import get_setting
+
 logger = logging.getLogger(__name__)
 
 _PROBE_URL = 'https://www.cloudflare.com/cdn-cgi/trace'
@@ -252,6 +254,25 @@ def switch_server(
         raw = filter_value if uses_server_filter and var == env_var else ''
         env_lines += f'      {var}: "{_safe(raw)}"\n'
 
+    # DNS filtering is managed by Companion as well, so the user's choice
+    # survives every regenerated override and provider/server switch.
+    try:
+        dns_block_malicious = get_setting('dns_block_malicious', '1')
+        dns_unblock_hostnames = get_setting('dns_unblock_hostnames', '')
+    except Exception:
+        # Keep standalone uses and early-startup recovery aligned with
+        # Gluetun's own secure default if the settings DB is unavailable.
+        dns_block_malicious = '1'
+        dns_unblock_hostnames = ''
+    env_lines += (
+        '      BLOCK_MALICIOUS: "'
+        + ('on' if dns_block_malicious == '1' else 'off')
+        + '"\n'
+    )
+    env_lines += (
+        f'      DNS_UNBLOCK_HOSTNAMES: "{_safe(dns_unblock_hostnames)}"\n'
+    )
+
     # VPN profile vars (provider + type + credentials)
     if wg_profile:
         if compose_provider:
@@ -308,6 +329,101 @@ def switch_server(
             err = (result.stderr or result.stdout or 'unknown error').strip()
             logger.error('docker compose failed: %s', err)
             return False, err
+        return True, None
+    except subprocess.TimeoutExpired:
+        return False, 'docker compose timed out after 90s'
+    except FileNotFoundError:
+        return False, 'docker binary not found in PATH'
+
+
+def apply_dns_filtering(
+    container_name: str,
+    compose_dir: str,
+    block_malicious: bool,
+    unblock_hostnames: str = '',
+    compose_project: str = '',
+) -> tuple[bool, str | None]:
+    """Persist DNS filtering values in Companion's override and recreate Gluetun."""
+    service = _detect_compose_service(container_name)
+    project = compose_project or _detect_compose_project(container_name)
+    override_path = os.path.join(compose_dir, 'docker-compose.override.yml')
+
+    def _safe(raw: str) -> str:
+        return raw.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '').replace('\r', '')
+
+    values = {
+        'BLOCK_MALICIOUS': 'on' if block_malicious else 'off',
+        'DNS_UNBLOCK_HOSTNAMES': unblock_hostnames,
+    }
+
+    try:
+        network_dependents = list_network_dependents_for_recreate(container_name)
+    except Exception as exc:
+        logger.warning('Unable to list network dependents before DNS update: %s', exc)
+        network_dependents = []
+
+    try:
+        if os.path.exists(override_path):
+            with open(override_path, encoding='utf-8') as fh:
+                lines = fh.readlines()
+        else:
+            lines = ['services:\n', f'  {service}:\n', '    environment:\n']
+
+        environment_idx = next(
+            (i for i, line in enumerate(lines) if line.rstrip() == '    environment:'),
+            None,
+        )
+        if environment_idx is None:
+            service_idx = next(
+                (i for i, line in enumerate(lines) if line.rstrip() == f'  {service}:'),
+                None,
+            )
+            if service_idx is None:
+                if lines and not lines[-1].endswith('\n'):
+                    lines[-1] += '\n'
+                lines.extend([f'  {service}:\n', '    environment:\n'])
+                environment_idx = len(lines) - 1
+            else:
+                lines.insert(service_idx + 1, '    environment:\n')
+                environment_idx = service_idx + 1
+
+        for key, value in values.items():
+            replacement = f'      {key}: "{_safe(value)}"\n'
+            existing_idx = next(
+                (i for i, line in enumerate(lines) if line.lstrip().startswith(f'{key}:')),
+                None,
+            )
+            if existing_idx is None:
+                environment_idx += 1
+                lines.insert(environment_idx, replacement)
+            else:
+                lines[existing_idx] = replacement
+
+        tmp_path = override_path + '.tmp'
+        with open(tmp_path, 'w', encoding='utf-8', newline='\n') as fh:
+            fh.writelines(lines)
+        os.replace(tmp_path, override_path)
+    except OSError as exc:
+        return False, f'Cannot write override file: {exc}'
+
+    cmd = ['docker', 'compose']
+    if project:
+        cmd += ['-p', project]
+    cmd += ['up', '-d', service]
+    mark_companion_restart()
+    try:
+        result = subprocess.run(
+            cmd, cwd=compose_dir, capture_output=True, text=True, timeout=90,
+        )
+        if result.returncode != 0:
+            return False, (result.stderr or result.stdout or 'unknown error').strip()
+        if network_dependents:
+            restart_network_dependents(
+                container_name,
+                compose_dir,
+                project,
+                explicit_list=network_dependents,
+            )
         return True, None
     except subprocess.TimeoutExpired:
         return False, 'docker compose timed out after 90s'

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -579,6 +579,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'flash_catalogue_saved':    'Configuration du catalogue enregistrée.',
         'flash_post_switch_saved':  'Containers post-bascule enregistrés.',
         'flash_pause_bench_saved':  'Containers en pause pendant le benchmark enregistrés.',
+        'flash_dns_filter_saved':   'Filtrage DNS appliqué à Gluetun.',
+        'flash_dns_filter_invalid': 'La liste des domaines contient des caractères invalides.',
+        'flash_dns_filter_restart_failed': 'Réglage enregistré, mais Gluetun n’a pas pu être recréé : {err}',
 
         # ── Sidecar ──
         'set_sidecar_title':              'Mode Sidecar (défaut)',
@@ -1582,6 +1585,9 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'flash_catalogue_saved':    'Catalogue configuration saved.',
         'flash_post_switch_saved':  'Post-switch containers saved.',
         'flash_pause_bench_saved':  'Containers to pause during benchmark saved.',
+        'flash_dns_filter_saved':   'DNS filtering applied to Gluetun.',
+        'flash_dns_filter_invalid': 'The domain list contains invalid characters.',
+        'flash_dns_filter_restart_failed': 'Setting saved, but Gluetun could not be recreated: {err}',
 
         # ── Sidecar ──
         'set_sidecar_title':              'Sidecar Mode (default)',

--- a/app/routes.py
+++ b/app/routes.py
@@ -33,6 +33,7 @@ from .gluetun import (
     FILTER_VARS, FILTER_LABELS,
     get_current_filters, format_filters,
     get_public_ip, get_public_ips, get_vpn_status, switch_server,
+    apply_dns_filtering,
     wait_for_vpn, restart_network_dependents,
     list_docker_containers,
 )
@@ -1848,6 +1849,29 @@ def settings():
                 save_tracker_settings(80, 3, 12)
             flash_t('flash_settings_saved', 'success')
 
+        elif action == 'dns_filtering':
+            block_malicious = bool(request.form.get('dns_block_malicious'))
+            raw_hostnames = request.form.get('dns_unblock_hostnames', '')
+            hostnames = ','.join(
+                item.strip() for item in raw_hostnames.split(',') if item.strip()
+            )
+            if any(char in hostnames for char in ('\n', '\r', '"', '\\')):
+                flash_t('flash_dns_filter_invalid', 'danger')
+            else:
+                set_setting('dns_block_malicious', '1' if block_malicious else '0')
+                set_setting('dns_unblock_hostnames', hostnames)
+                ok, error = apply_dns_filtering(
+                    current_app.config['GLUETUN_CONTAINER'],
+                    current_app.config['COMPOSE_DIR'],
+                    block_malicious,
+                    hostnames,
+                )
+                if ok:
+                    flash_t('flash_dns_filter_saved', 'success')
+                else:
+                    logger.error('Applying Gluetun DNS filtering failed: %s', error)
+                    flash_t('flash_dns_filter_restart_failed', 'danger', err=error)
+
         elif action == 'port_forward_settings':
             set_setting('port_forward_enabled', '1' if request.form.get('port_forward_enabled') else '0')
             set_setting('port_forward_auto_sync', '1' if request.form.get('port_forward_auto_sync') else '0')
@@ -2163,6 +2187,8 @@ def settings():
         'tracker_check_threshold_pct':    get_setting('tracker_check_threshold_pct', '80'),
         'tracker_check_timeout_secs':     get_setting('tracker_check_timeout_secs', '3'),
         'tracker_check_concurrency':      get_setting('tracker_check_concurrency', '12'),
+        'dns_block_malicious':            get_setting('dns_block_malicious', '1'),
+        'dns_unblock_hostnames':          get_setting('dns_unblock_hostnames', ''),
         'port_forward_enabled':           get_setting('port_forward_enabled', '0'),
         'port_forward_auto_sync':         get_setting('port_forward_auto_sync', '0'),
         'port_forward_gluetun_api_url':   get_setting('port_forward_gluetun_api_url', 'http://host.docker.internal:8000'),

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -2014,6 +2014,59 @@
    ═════════════════════════════════════════════════════════════════════════════ #}
 <section class="settings-section">
 
+  <div class="card p-4 mb-4" id="card-dns-filtering">
+    <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
+      <div>
+        <h6 class="fw-bold mb-1 text-warning">
+          <i class="bi bi-shield-check"></i>
+          {{ 'Filtrage DNS Gluetun' if session.get('lang','fr') == 'fr' else 'Gluetun DNS filtering' }}
+        </h6>
+        <p class="text-muted mb-0 settings-wide-hint">
+          {{ 'Gluetun bloque les domaines malveillants par défaut. Ce filtrage peut parfois bloquer l’URL d’annonce d’un tracker BitTorrent.' if session.get('lang','fr') == 'fr' else 'Gluetun blocks malicious domains by default. This filtering can occasionally block a BitTorrent tracker announce URL.' }}
+        </p>
+      </div>
+      <span id="dns-filtering-badge" class="badge {{ 'bg-success' if cfg.dns_block_malicious == '1' else 'bg-warning text-dark' }}">
+        {{ 'ON' if cfg.dns_block_malicious == '1' else 'OFF' }}
+      </span>
+    </div>
+
+    <form method="post" class="row g-3">
+      <input type="hidden" name="action" value="dns_filtering">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+      <div class="col-12">
+        <div class="form-check form-switch">
+          <input type="checkbox" name="dns_block_malicious" class="form-check-input"
+                 id="dns_block_malicious" {{ 'checked' if cfg.dns_block_malicious == '1' }}>
+          <label class="form-check-label fw-semibold" for="dns_block_malicious">
+            {{ 'Bloquer les domaines malveillants (recommandé)' if session.get('lang','fr') == 'fr' else 'Block malicious domains (recommended)' }}
+          </label>
+          <div class="form-text">
+            {{ 'Pilote BLOCK_MALICIOUS. La désactivation réduit la protection DNS de tous les containers utilisant le réseau de Gluetun.' if session.get('lang','fr') == 'fr' else 'Controls BLOCK_MALICIOUS. Disabling it reduces DNS protection for every container using Gluetun’s network.' }}
+          </div>
+        </div>
+      </div>
+      <div class="col-12">
+        <label class="form-label small mb-1" for="dns_unblock_hostnames">
+          {{ 'Domaines à autoriser malgré le filtrage' if session.get('lang','fr') == 'fr' else 'Domains to allow through filtering' }}
+        </label>
+        <input type="text" name="dns_unblock_hostnames" id="dns_unblock_hostnames"
+               class="form-control form-control-sm font-monospace"
+               value="{{ cfg.dns_unblock_hostnames }}" placeholder="tracker.example.org,announce.example.net">
+        <div class="form-text">
+          {{ 'Correspond à DNS_UNBLOCK_HOSTNAMES. Séparez les domaines par des virgules. Préférez cette exception ciblée à la désactivation complète.' if session.get('lang','fr') == 'fr' else 'Maps to DNS_UNBLOCK_HOSTNAMES. Separate domains with commas. Prefer this targeted exception over disabling all protection.' }}
+        </div>
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-sm btn-warning fw-semibold">
+          <i class="bi bi-save"></i> {{ t.cmn_save }}
+        </button>
+        <span class="small text-muted ms-2">
+          {{ 'Gluetun sera recréé immédiatement.' if session.get('lang','fr') == 'fr' else 'Gluetun will be recreated immediately.' }}
+        </span>
+      </div>
+    </form>
+  </div>
+
   <div class="card p-4 mb-4" id="card-tracker-settings">
     <div class="d-flex justify-content-between align-items-start gap-3 mb-3">
       <div>
@@ -2945,6 +2998,7 @@ function arrangeSettingsTabs() {
   ].forEach(el => move(pane('settings-notifications-grid'), el));
 
   [
+    byId('card-dns-filtering'),
     byId('card-tracker-settings'),
     byId('card-torrent-clients'),
     byId('card-tracker-list'),
@@ -3162,6 +3216,17 @@ if (document.readyState === 'loading') {
         submitter.innerHTML = oldHtml;
       }
     }
+  });
+})();
+
+// Keep the DNS filtering status badge aligned with the switch before saving.
+(function () {
+  const toggle = document.getElementById('dns_block_malicious');
+  const badge = document.getElementById('dns-filtering-badge');
+  if (!toggle || !badge) return;
+  toggle.addEventListener('change', () => {
+    badge.textContent = toggle.checked ? 'ON' : 'OFF';
+    badge.className = `badge ${toggle.checked ? 'bg-success' : 'bg-warning text-dark'}`;
   });
 })();
 

--- a/tests/test_gluetun_override.py
+++ b/tests/test_gluetun_override.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
-from app.gluetun import switch_server
+from app.gluetun import apply_dns_filtering, switch_server
 
 
 class SwitchServerOverrideTest(TestCase):
@@ -47,3 +47,62 @@ class SwitchServerOverrideTest(TestCase):
         self.assertEqual(override.count('SERVER_NAMES:'), 1)
         self.assertIn('SERVER_NAMES: "Dalim"', override)
         self.assertEqual(override.count('WIREGUARD_PRIVATE_KEY:'), 1)
+
+    def test_switch_preserves_dns_filtering_settings(self) -> None:
+        with TemporaryDirectory() as directory:
+            with (
+                patch('app.gluetun._detect_compose_project', return_value='airvpn'),
+                patch('app.gluetun._detect_compose_service', return_value='gluetun-airvpn'),
+                patch('app.gluetun.mark_companion_restart'),
+                patch('app.gluetun.get_setting', side_effect=lambda key, default='': {
+                    'dns_block_malicious': '0',
+                    'dns_unblock_hostnames': 'tracker.example.org',
+                }.get(key, default), create=True),
+                patch('app.gluetun.subprocess.run') as run,
+            ):
+                run.return_value.returncode = 0
+                run.return_value.stderr = ''
+                run.return_value.stdout = ''
+                success, error = switch_server(
+                    'Dalim', 'server_names', 'gluetun-airvpn', directory,
+                )
+                override = (Path(directory) / 'docker-compose.override.yml').read_text()
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertIn('BLOCK_MALICIOUS: "off"', override)
+        self.assertIn('DNS_UNBLOCK_HOSTNAMES: "tracker.example.org"', override)
+
+    def test_apply_dns_filtering_updates_existing_override(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / 'docker-compose.override.yml'
+            path.write_text(
+                'services:\n  gluetun-airvpn:\n    environment:\n'
+                '      SERVER_NAMES: "Dalim"\n      BLOCK_MALICIOUS: "on"\n',
+                encoding='utf-8',
+            )
+            with (
+                patch('app.gluetun._detect_compose_project', return_value='airvpn'),
+                patch('app.gluetun._detect_compose_service', return_value='gluetun-airvpn'),
+                patch('app.gluetun.mark_companion_restart'),
+                patch('app.gluetun.list_network_dependents_for_recreate', return_value=['qbittorrent']),
+                patch('app.gluetun.restart_network_dependents') as restart_dependents,
+                patch('app.gluetun.subprocess.run') as run,
+            ):
+                run.return_value.returncode = 0
+                run.return_value.stderr = ''
+                run.return_value.stdout = ''
+                success, error = apply_dns_filtering(
+                    'gluetun-airvpn', directory, False, 'tracker.example.org',
+                )
+                override = path.read_text(encoding='utf-8')
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertEqual(override.count('BLOCK_MALICIOUS:'), 1)
+        self.assertIn('BLOCK_MALICIOUS: "off"', override)
+        self.assertIn('DNS_UNBLOCK_HOSTNAMES: "tracker.example.org"', override)
+        self.assertIn('SERVER_NAMES: "Dalim"', override)
+        restart_dependents.assert_called_once_with(
+            'gluetun-airvpn', directory, 'airvpn', explicit_list=['qbittorrent'],
+        )


### PR DESCRIPTION
## Résumé

- précise dans les README que Gluetun active `BLOCK_MALICIOUS=on` par défaut ;
- ajoute dans **Paramètres → Trackers** un interrupteur permettant de conserver ou désactiver ce filtrage ;
- ajoute une liste d’exceptions ciblées reposant sur `DNS_UNBLOCK_HOSTNAMES`, recommandée lorsqu’une URL d’annonce est bloquée ;
- applique immédiatement le réglage dans `docker-compose.override.yml` et recrée Gluetun ;
- recrée ensuite les containers dépendant du namespace réseau de Gluetun, notamment qBittorrent ;
- conserve les deux réglages lors des futures bascules de serveur ou de fournisseur.

## Sécurité

Le filtrage reste activé par défaut. L’interface avertit que sa désactivation réduit la protection DNS de tous les containers partageant le réseau de Gluetun et recommande d’autoriser uniquement le domaine du tracker concerné.

## Validation

- 15 tests unitaires réussis ;
- compilation Python réussie ;
- compilation du template Jinja réussie ;
- absence de clés DNS dupliquées dans l’override vérifiée ;
- persistance lors des bascules et recréation des dépendants réseau testées ;
- contrôle UTF-8 et `git diff --check` réussis.
