### PR TITLE
refactor: renommer l'onglet Trackers en BitTorrent dans /settings

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -347,7 +347,7 @@ The **VPN Status** card displays the intermediary and observed operators. In tab
 - **Automatic Docker image updates** *(option)* — at switch time, Companion can update images before restarting containers: Gluetun itself, auto-managed network containers, post-switch containers and benchmark-paused containers; togglable per container from Settings
 
 ### BitTorrent tracker checks
-- **Multiple clients** — configure one or more qBittorrent or rTorrent/ruTorrent clients in **Settings → Trackers**; each client can be a tracker source, even if its container is also stopped during benchmarks
+- **Multiple clients** — configure one or more qBittorrent or rTorrent/ruTorrent clients in **Settings → BitTorrent**; each client can be a tracker source, even if its container is also stopped during benchmarks
 - **Persistent discovery** — Companion fetches tracker URLs from loaded torrents, deduplicates them, then displays source clients, torrent count, last check and success status
 - **Passkeys hidden** — private passkeys and tokens are stripped from detected URLs before storage/display, including query-string keys and token-like path segments
 - **Per-URL control** — each tracker can be enabled or ignored individually for future checks
@@ -475,9 +475,9 @@ In **Settings → Measure → Containers to pause during benchmark**: list of co
 
 ### BitTorrent tracker checks through the VPN
 
-In **Settings → Trackers**, Companion can verify whether the trackers actually used by your torrents are reachable from the VPN server being tested or selected. The goal is not to perform a full real announce for every torrent, but to verify useful connectivity with four levels:
+In **Settings → BitTorrent**, Companion can verify whether the trackers actually used by your torrents are reachable from the VPN server being tested or selected. The goal is not to perform a full real announce for every torrent, but to verify useful connectivity with four levels:
 
-According to the [official Gluetun DNS documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/dns.md), Gluetun enables `BLOCK_MALICIOUS=on` by default. Some announce URLs may therefore be blocked by its DNS lists even when the tracker is available. Under **Settings → Trackers → Gluetun DNS filtering**, Companion can keep this protection enabled while allowing specific domains through `DNS_UNBLOCK_HOSTNAMES`, or disable `BLOCK_MALICIOUS` entirely as a last resort. The setting is written to `docker-compose.override.yml`, applied immediately by recreating Gluetun, and preserved across subsequent switches. Disabling it globally reduces DNS protection for every container sharing Gluetun's network; a targeted exception is recommended.
+According to the [official Gluetun DNS documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/dns.md), Gluetun enables `BLOCK_MALICIOUS=on` by default. Some announce URLs may therefore be blocked by its DNS lists even when the tracker is available. Under **Settings → BitTorrent → Gluetun DNS filtering**, Companion can keep this protection enabled while allowing specific domains through `DNS_UNBLOCK_HOSTNAMES`, or disable `BLOCK_MALICIOUS` entirely as a last resort. The setting is written to `docker-compose.override.yml`, applied immediately by recreating Gluetun, and preserved across subsequent switches. Disabling it globally reduces DNS protection for every container sharing Gluetun's network; a targeted exception is recommended.
 
 1. **DNS** — the tracker domain can be resolved.
 2. **Port** — the TCP/UDP tracker port responds.
@@ -486,7 +486,7 @@ According to the [official Gluetun DNS documentation](https://github.com/qdm12/g
 
 This threshold avoids false negatives: a private or public tracker can be temporarily down without making the VPN server bad. Companion stores per-URL history so it can gradually distinguish globally unavailable trackers from trackers blocked only on specific VPN paths.
 
-Two separate toggles are available in **Settings → Trackers**:
+Two separate toggles are available in **Settings → BitTorrent**:
 
 - **Enable tracker checks during VPN verification** runs discovery before benchmarks, then checks enabled URLs for each tested server.
 - **Require an OK tracker result for automatic switches and pools** turns that score into an eligibility criterion: during a benchmark, servers below the threshold are excluded from the final pick; in pool rotation, servers already known below threshold are ignored, while never-tested servers remain candidates.

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ L'encart **Statut VPN** affiche l'intermédiaire et les opérateurs observés. D
 - **Mise à jour automatique des images Docker** *(option)* — au moment de la bascule, Companion peut mettre à jour les images avant de relancer les containers : Gluetun lui-même, les containers réseau auto-gérés, les containers à redémarrer après bascule et les containers en pause pendant le benchmark ; activable individuellement par container depuis les Paramètres
 
 ### Contrôle trackers BitTorrent
-- **Clients multiples** — configurez un ou plusieurs clients qBittorrent ou rTorrent/ruTorrent dans **Paramètres → Trackers** ; chaque client peut servir de source de trackers, même s'il fait aussi partie des containers stoppés pendant le benchmark
+- **Clients multiples** — configurez un ou plusieurs clients qBittorrent ou rTorrent/ruTorrent dans **Paramètres → BitTorrent** ; chaque client peut servir de source de trackers, même s'il fait aussi partie des containers stoppés pendant le benchmark
 - **Découverte persistante** — Companion récupère les URLs de trackers depuis les torrents chargés, les déduplique, puis affiche la liste avec source, nombre de torrents, dernier test et taux de réussite
 - **Passkeys masquées** — les passkeys et tokens privés sont retirés des URLs détectées avant stockage/affichage, y compris quand ils sont dans la query string ou dans le chemin
 - **Contrôle par URL** — chaque tracker peut être activé ou ignoré individuellement pour les vérifications futures
@@ -474,9 +474,9 @@ Dans **Paramètres → Mesurer → Containers à stopper pendant le benchmark** 
 
 ### Contrôle des trackers BitTorrent via le VPN
 
-Dans **Paramètres → Trackers**, Companion peut vérifier si les trackers réellement utilisés par vos torrents sont accessibles depuis le serveur VPN testé ou sélectionné. L'objectif n'est pas de faire un vrai announce complet pour chaque torrent, mais de vérifier la connectivité utile avec quatre niveaux :
+Dans **Paramètres → BitTorrent**, Companion peut vérifier si les trackers réellement utilisés par vos torrents sont accessibles depuis le serveur VPN testé ou sélectionné. L'objectif n'est pas de faire un vrai announce complet pour chaque torrent, mais de vérifier la connectivité utile avec quatre niveaux :
 
-D’après la [documentation DNS officielle de Gluetun](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/dns.md), Gluetun active `BLOCK_MALICIOUS=on` par défaut. Certaines URL d'annonce peuvent donc être bloquées par ses listes DNS même si le tracker est disponible. Dans **Paramètres → Trackers → Filtrage DNS Gluetun**, Companion permet de conserver cette protection tout en autorisant des domaines précis via `DNS_UNBLOCK_HOSTNAMES`, ou de désactiver entièrement `BLOCK_MALICIOUS` en dernier recours. Le réglage est écrit dans `docker-compose.override.yml`, appliqué immédiatement en recréant Gluetun et conservé lors des bascules suivantes. La désactivation globale réduit la protection DNS de tous les containers partageant le réseau de Gluetun ; l'exception ciblée est recommandée.
+D’après la [documentation DNS officielle de Gluetun](https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/dns.md), Gluetun active `BLOCK_MALICIOUS=on` par défaut. Certaines URL d'annonce peuvent donc être bloquées par ses listes DNS même si le tracker est disponible. Dans **Paramètres → BitTorrent → Filtrage DNS Gluetun**, Companion permet de conserver cette protection tout en autorisant des domaines précis via `DNS_UNBLOCK_HOSTNAMES`, ou de désactiver entièrement `BLOCK_MALICIOUS` en dernier recours. Le réglage est écrit dans `docker-compose.override.yml`, appliqué immédiatement en recréant Gluetun et conservé lors des bascules suivantes. La désactivation globale réduit la protection DNS de tous les containers partageant le réseau de Gluetun ; l'exception ciblée est recommandée.
 
 1. **DNS** — le domaine du tracker peut être résolu.
 2. **Port** — le port TCP/UDP du tracker répond.
@@ -485,7 +485,7 @@ D’après la [documentation DNS officielle de Gluetun](https://github.com/qdm12
 
 Ce seuil évite les faux négatifs : un tracker privé ou public peut être temporairement down, sans que le serveur VPN soit mauvais. Companion conserve l'historique par URL afin de distinguer progressivement un tracker globalement indisponible d'un tracker bloqué seulement sur certains chemins VPN.
 
-Deux usages sont séparés dans **Paramètres → Trackers** :
+Deux usages sont séparés dans **Paramètres → BitTorrent** :
 
 - **Activer le contrôle trackers pendant les vérifications VPN** lance la découverte avant benchmark, puis teste les URLs activées pour chaque serveur testé.
 - **Exiger un résultat trackers OK pour les bascules automatiques et les pools** transforme ce score en critère d'éligibilité : pendant un benchmark, les serveurs sous le seuil sont exclus du choix final ; dans une rotation de pool, les serveurs déjà connus sous le seuil sont ignorés, tandis que les serveurs jamais testés restent candidats.

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -498,7 +498,7 @@
     </li>
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="tab-trackers" data-bs-toggle="tab" data-bs-target="#settings-trackers" type="button" role="tab">
-        <i class="bi bi-broadcast-pin me-1"></i>Trackers
+        <i class="bi bi-broadcast-pin me-1"></i>BitTorrent
       </button>
     </li>
     <li class="nav-item" role="presentation">
@@ -643,7 +643,7 @@
         <div id="settings-trackers-grid" class="settings-pane-main"></div>
         <aside class="settings-pane-aside">
           <div class="settings-help-card">
-            <h6><i class="bi bi-broadcast-pin me-1"></i>Trackers</h6>
+            <h6><i class="bi bi-broadcast-pin me-1"></i>BitTorrent</h6>
             <div class="metric"><span>Clients</span><strong id="tracker-summary-clients">{{ trackers_summary.clients }}</strong></div>
             <div class="metric"><span>{{ 'URLs connues' if session.get('lang','fr') == 'fr' else 'Known URLs' }}</span><strong id="tracker-summary-total">{{ trackers_summary.total }}</strong></div>
             <div class="metric"><span>{{ 'Contrôlées' if session.get('lang','fr') == 'fr' else 'Checked' }}</span><strong id="tracker-summary-enabled">{{ trackers_summary.enabled }}</strong></div>


### PR DESCRIPTION
## Objectif

Renommer l'onglet **Trackers** de la page `/settings` en **BitTorrent**, et mettre à jour la documentation en conséquence.

## Modifications

**Code (`app/templates/settings.html`)**
- Label de l'onglet : `Trackers` → `BitTorrent`
- Titre miroir dans l'aside de l'onglet : `Trackers` → `BitTorrent`
- Conservés : identifiants techniques (`tab-trackers`, `settings-trackers`, `settings-trackers-grid`) et titres des cartes internes (« Contrôle des trackers BitTorrent », « URLs de trackers détectées ») — ils décrivent la fonctionnalité trackers, toujours hébergée dans cette section.

**Documentation**
- `README.md` : renvois `Paramètres → Trackers` → `Paramètres → BitTorrent` (dont le chemin `→ BitTorrent → Filtrage DNS Gluetun`)
- `README.en.md` : renvois `Settings → Trackers` → `Settings → BitTorrent` (dont `→ BitTorrent → Gluetun DNS filtering`)

## Laissé volontairement inchangé

- La colonne **Trackers** de la page Serveurs (`servers.html` + descriptions README) : élément distinct de l'onglet (résultats de contrôle par serveur).
- Les occurrences `Tracker` dans `scheduler.py` / `torrent_trackers.py` : code interne (logs, noms de fonctions), sans lien avec le nom affiché de l'onglet.

## Vérifications

- Parsing Jinja de `settings.html` : OK
- Diff limité à 3 fichiers (10 insertions / 10 suppressions)


