### PR TITLE
feat: afficher la Mappemonde des serveurs sur les onglets BitTorrent et Port Forwarding

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -642,6 +642,7 @@
       <div class="settings-pane-layout">
         <div id="settings-trackers-grid" class="settings-pane-main"></div>
         <aside class="settings-pane-aside">
+          {{ settings_world_map() }}
           <div class="settings-help-card">
             <h6><i class="bi bi-broadcast-pin me-1"></i>BitTorrent</h6>
             <div class="metric"><span>Clients</span><strong id="tracker-summary-clients">{{ trackers_summary.clients }}</strong></div>
@@ -660,6 +661,7 @@
       <div class="settings-pane-layout">
         <div id="settings-port-forwarding-grid" class="settings-pane-main"></div>
         <aside class="settings-pane-aside">
+          {{ settings_world_map() }}
           <div class="settings-help-card">
             <h6><i class="bi bi-diagram-3 me-1"></i>{{ 'Port forwarding' if session.get('lang','fr') == 'fr' else 'Port forwarding' }}</h6>
             <div class="metric"><span>{{ 'Règles' if session.get('lang','fr') == 'fr' else 'Rules' }}</span><strong>{{ port_forwards | length }}</strong></div>


### PR DESCRIPTION
## Objectif

Afficher la **Mappemonde des serveurs** dans les onglets **BitTorrent** et **Port Forwarding** de `/settings`, pour être cohérent avec les autres onglets.

## Modifications

`app/templates/settings.html` : ajout de l'appel au macro `settings_world_map()` en tête de l'aside des deux onglets concernés (`settings-trackers` et `settings-port-forwarding`), au même emplacement que sur les onglets Mesurer, Décider, Profils VPN, Notifications et Maintenance.

Aucune nouvelle logique : le macro et ses données (`settings_sidebar.map_points`) existaient déjà et sont simplement réutilisés.

## Vérifications

- Parsing Jinja de `settings.html` : OK
- La map est désormais appelée sur les 7 onglets (1 définition de macro + 7 appels)

