### PR TITLE
fix: rendre visible le point du serveur courant sur la carte des serveurs

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -108,6 +108,11 @@
     stroke: var(--bs-body-color);
     stroke-width: 1.6;
   }
+  .dash-map-point-halo {
+    fill: var(--bs-warning);
+    opacity: .25;
+    stroke: none;
+  }
   /* obs-* styles moved to base.html */
   .pool-activity-scroll {
     max-height: 34rem;
@@ -500,11 +505,24 @@
       <div class="dash-world-map">
         <svg viewBox="0 0 1000 520" role="img" aria-label="{{ t.dash_map_title }}">
           <image class="dash-map-base" href="{{ url_for('static', filename='world-map.svg') }}" x="0" y="0" width="1000" height="520"/>
-          {% for p in dashboard_map_points %}
+          {# non-active servers first #}
+          {% for p in dashboard_map_points if not p.active %}
             {% set x = ((p.lon + 180) / 360 * 1000) %}
             {% set y = ((90 - p.lat) / 180 * 520) %}
             {% set radius = 4 + ([p.uses, 18] | min) * 0.45 %}
-            <circle class="{{ 'dash-map-point-active' if p.active else 'dash-map-point' }}"
+            <circle class="dash-map-point"
+                    cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
+              <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
+            </circle>
+          {% endfor %}
+          {# current server drawn last, with a halo, so it is never hidden by overlapping points #}
+          {% for p in dashboard_map_points if p.active %}
+            {% set x = ((p.lon + 180) / 360 * 1000) %}
+            {% set y = ((90 - p.lat) / 180 * 520) %}
+            {% set radius = [4 + ([p.uses, 18] | min) * 0.45, 6.5] | max %}
+            <circle class="dash-map-point-halo"
+                    cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius + 3) }}"/>
+            <circle class="dash-map-point-active"
                     cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
               <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
             </circle>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -160,6 +160,11 @@
     stroke: var(--bs-body-color);
     stroke-width: 1.6;
   }
+  .settings-map-point-halo {
+    fill: var(--bs-warning);
+    opacity: .25;
+    stroke: none;
+  }
   .settings-readme-card {
     max-height: 32rem;
     overflow: auto;
@@ -393,11 +398,24 @@
     <div class="settings-world-map">
       <svg viewBox="0 0 1000 520" role="img" aria-label="{{ t.set_side_world_map }}">
         <image class="settings-map-base" href="{{ url_for('static', filename='world-map.svg') }}" x="0" y="0" width="1000" height="520"/>
-        {% for p in settings_sidebar.map_points %}
+        {# non-active servers first #}
+        {% for p in settings_sidebar.map_points if not p.active %}
           {% set x = ((p.lon + 180) / 360 * 1000) %}
           {% set y = ((90 - p.lat) / 180 * 520) %}
           {% set radius = 4 + ([p.uses, 18] | min) * 0.45 %}
-          <circle class="{{ 'settings-map-point-active' if p.active else 'settings-map-point' }}"
+          <circle class="settings-map-point"
+                  cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
+            <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
+          </circle>
+        {% endfor %}
+        {# current server drawn last, with a halo, so it is never hidden by overlapping points #}
+        {% for p in settings_sidebar.map_points if p.active %}
+          {% set x = ((p.lon + 180) / 360 * 1000) %}
+          {% set y = ((90 - p.lat) / 180 * 520) %}
+          {% set radius = [4 + ([p.uses, 18] | min) * 0.45, 6.5] | max %}
+          <circle class="settings-map-point-halo"
+                  cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius + 3) }}"/>
+          <circle class="settings-map-point-active"
                   cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
             <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
           </circle>


### PR DESCRIPTION
## Problème

Sur `/` (dashboard) et dans `/settings`, le **point jaune** indiquant la localisation du serveur VPN en cours d'utilisation n'apparaissait plus.

Cause : les points de la carte utilisent des coordonnées au **niveau pays**. Plusieurs serveurs d'un même pays se superposent donc exactement. Le point actif était dessiné dans l'ordre de la liste (par nombre d'usages), et les points bleus (opacité .82) dessinés ensuite au même endroit le recouvraient — le jaune devenait invisible.

## Correction

Rendu de la carte en **deux passes** (dans `dashboard.html` et le macro `settings_world_map()` de `settings.html`) :

1. Les serveurs **non actifs** (bleus) d'abord.
2. Le **serveur courant** en dernier, donc toujours au-dessus, avec :
   - un **halo** translucide (nouvelle classe `*-map-point-halo`),
   - un **rayon minimum** (6.5) pour qu'il reste bien visible même superposé à d'autres points.

L'indication reste dérivée du serveur réel courant via `get_current_filters()`, donc à jour à chaque changement de serveur (au rechargement de la page).

## Vérifications

- Parsing Jinja de `dashboard.html` et `settings.html` : OK
- Logique Python inchangée : le flag `active` et le point de repli du serveur courant existaient déjà côté routes
