### PR TITLE
feat: carte des serveurs interactive (tooltip riche, zoom/pan, 60 serveurs)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -179,8 +179,50 @@ _COUNTRY_COORDS = {
 }
 
 
+def _provider_icon_url(provider: str) -> str:
+    """Return the URL of a provider's icon, or '' when none is available.
+
+    Mirrors the priority used by the ``server_provider_icon`` template helper:
+    bundled SVG first, then the server-side cached favicon route.
+    """
+    if not provider:
+        return ''
+    try:
+        if provider in PROVIDER_SVG_FILES:
+            return url_for('static', filename=f'providers/{provider}.svg')
+        if provider in PROVIDER_FAVICON_DOMAINS:
+            return url_for('main.provider_icon', provider=provider)
+    except Exception:
+        return ''
+    return ''
+
+
+# Number of most-tested servers shown on the world map (plus the current one).
+_MAP_SERVER_LIMIT = 60
+
+
 def _server_map_points(db, active_server_name: str = '') -> list[dict]:
-    """Return map points for the 30 most tested servers plus the current server."""
+    """Return map points for the most tested servers plus the current server.
+
+    Each point carries the server's flag country, VPN provider (and its icon
+    URL) and the number of successful tests, for the hover tooltip.
+    """
+    # Provider per server: explicit VPN profile, else AirVPN when the server is
+    # present in the AirVPN snapshot.
+    prov_map: dict[str, str] = {}
+    try:
+        for r in db.execute(
+            'SELECT s.name, vp.provider FROM servers s '
+            'JOIN vpn_profiles vp ON vp.id = s.vpn_profile_id '
+            "WHERE COALESCE(vp.provider, '') != ''"
+        ).fetchall():
+            prov_map[r['name']] = (r['provider'] or '').lower()
+    except Exception:
+        pass
+
+    def _provider_for(name: str, av_name) -> str:
+        return prov_map.get(name) or ('airvpn' if av_name else '')
+
     rows = db.execute(
         '''WITH catalogue_country AS (
                SELECT name,
@@ -192,14 +234,16 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
            SELECT st.server_name,
                   COUNT(DISTINCT st.id) AS uses,
                   COALESCE(NULLIF(av.country_code, ''), cc.country_code) AS country_code,
-                  COALESCE(NULLIF(av.country, ''), cc.country) AS country
+                  COALESCE(NULLIF(av.country, ''), cc.country) AS country,
+                  MAX(av.name) AS av_name
            FROM speed_tests st
            LEFT JOIN airvpn_snapshot av ON av.name = st.server_name
            LEFT JOIN catalogue_country cc ON cc.name = st.server_name
            WHERE st.success = 1
            GROUP BY st.server_name
            ORDER BY uses DESC, MAX(st.tested_at) DESC
-           LIMIT 30'''
+           LIMIT ?''',
+        (_MAP_SERVER_LIMIT,),
     ).fetchall()
     points = []
     names = set()
@@ -208,6 +252,7 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
         if cc not in _COUNTRY_COORDS:
             continue
         lat, lon = _COUNTRY_COORDS[cc]
+        provider = _provider_for(row['server_name'], row['av_name'])
         points.append({
             'server': row['server_name'],
             'uses': int(row['uses'] or 0),
@@ -215,6 +260,8 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
             'country_code': cc,
             'lat': lat,
             'lon': lon,
+            'provider': provider,
+            'provider_icon': _provider_icon_url(provider),
             'active': row['server_name'] == active_server_name,
         })
         names.add(row['server_name'])
@@ -230,7 +277,8 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
                )
                SELECT COALESCE(NULLIF(av.country_code, ''), cc.country_code) AS country_code,
                       COALESCE(NULLIF(av.country, ''), cc.country) AS country,
-                      COUNT(DISTINCT st.id) AS uses
+                      COUNT(DISTINCT st.id) AS uses,
+                      av.name AS av_name
                FROM (SELECT ? AS name) active
                LEFT JOIN airvpn_snapshot av ON av.name = active.name
                LEFT JOIN catalogue_country cc ON cc.name = active.name
@@ -241,6 +289,7 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
             cc = (row['country_code'] or '').lower()
             if cc in _COUNTRY_COORDS:
                 lat, lon = _COUNTRY_COORDS[cc]
+                provider = _provider_for(active_server_name, row['av_name'])
                 points.append({
                     'server': active_server_name,
                     'uses': int(row['uses'] or 0),
@@ -248,6 +297,8 @@ def _server_map_points(db, active_server_name: str = '') -> list[dict]:
                     'country_code': cc,
                     'lat': lat,
                     'lon': lon,
+                    'provider': provider,
+                    'provider_icon': _provider_icon_url(provider),
                     'active': True,
                 })
     return points
@@ -2249,26 +2300,6 @@ def settings():
         settings_sidebar['active_server'] = ''
         settings_sidebar['active_server_name'] = ''
     try:
-        _country_coords = {
-            'ad': (42.5, 1.6), 'ae': (24.4, 54.4), 'al': (41.3, 19.8), 'am': (40.2, 44.5),
-            'ar': (-34.6, -58.4), 'at': (48.2, 16.4), 'au': (-33.9, 151.2), 'az': (40.4, 49.9),
-            'ba': (43.9, 18.4), 'be': (50.8, 4.4), 'bg': (42.7, 23.3), 'br': (-23.5, -46.6),
-            'by': (53.9, 27.6), 'ca': (45.4, -75.7), 'ch': (47.4, 8.5), 'cl': (-33.4, -70.7),
-            'cn': (39.9, 116.4), 'co': (4.7, -74.1), 'cr': (9.9, -84.1), 'cy': (35.2, 33.4),
-            'cz': (50.1, 14.4), 'de': (52.5, 13.4), 'dk': (55.7, 12.6), 'ee': (59.4, 24.8),
-            'es': (40.4, -3.7), 'fi': (60.2, 24.9), 'fr': (48.9, 2.4), 'gb': (51.5, -0.1),
-            'ge': (41.7, 44.8), 'gr': (38.0, 23.7), 'hk': (22.3, 114.2), 'hr': (45.8, 16.0),
-            'hu': (47.5, 19.0), 'id': (-6.2, 106.8), 'ie': (53.3, -6.3), 'il': (32.1, 34.8),
-            'in': (28.6, 77.2), 'is': (64.1, -21.9), 'it': (41.9, 12.5), 'jp': (35.7, 139.7),
-            'kr': (37.6, 127.0), 'lt': (54.7, 25.3), 'lu': (49.6, 6.1), 'lv': (56.9, 24.1),
-            'md': (47.0, 28.8), 'mk': (42.0, 21.4), 'mt': (35.9, 14.5), 'mx': (19.4, -99.1),
-            'my': (3.1, 101.7), 'nl': (52.4, 4.9), 'no': (59.9, 10.8), 'nz': (-36.8, 174.8),
-            'pa': (9.0, -79.5), 'pe': (-12.0, -77.0), 'ph': (14.6, 121.0), 'pl': (52.2, 21.0),
-            'pt': (38.7, -9.1), 'ro': (44.4, 26.1), 'rs': (44.8, 20.5), 'ru': (55.8, 37.6),
-            'se': (59.3, 18.1), 'sg': (1.3, 103.8), 'si': (46.1, 14.5), 'sk': (48.1, 17.1),
-            'th': (13.8, 100.5), 'tr': (41.0, 29.0), 'tw': (25.0, 121.6), 'ua': (50.5, 30.5),
-            'us': (40.7, -74.0), 'uy': (-34.9, -56.2), 'vn': (10.8, 106.7), 'za': (-33.9, 18.4),
-        }
         counts = _server_history_counts()
         settings_sidebar['enabled_servers'] = counts['enabled']
         settings_sidebar['tested_servers'] = counts['tested']
@@ -2291,78 +2322,9 @@ def settings():
                    ORDER BY avg_dl DESC
                    LIMIT 5'''
             ).fetchall()
-            _map_rows = db.execute(
-                '''WITH catalogue_country AS (
-                       SELECT name,
-                              MAX(NULLIF(country_code, '')) AS country_code,
-                              MAX(NULLIF(country, '')) AS country
-                       FROM gluetun_catalogue
-                       GROUP BY name
-                   )
-                   SELECT st.server_name,
-                          COUNT(DISTINCT st.id) AS uses,
-                          COALESCE(NULLIF(av.country_code, ''), cc.country_code) AS country_code,
-                          COALESCE(NULLIF(av.country, ''), cc.country) AS country
-                   FROM speed_tests st
-                   LEFT JOIN airvpn_snapshot av ON av.name = st.server_name
-                   LEFT JOIN catalogue_country cc ON cc.name = st.server_name
-                   WHERE st.success = 1
-                   GROUP BY st.server_name
-                   ORDER BY uses DESC, MAX(st.tested_at) DESC
-                   LIMIT 30'''
-            ).fetchall()
-            _points = []
-            _point_names = set()
-            for r in _map_rows:
-                cc = (r['country_code'] or '').lower()
-                if cc not in _country_coords:
-                    continue
-                lat, lon = _country_coords[cc]
-                _points.append({
-                    'server': r['server_name'],
-                    'uses': int(r['uses'] or 0),
-                    'country': r['country'] or cc.upper(),
-                    'country_code': cc,
-                    'lat': lat,
-                    'lon': lon,
-                    'active': r['server_name'] == settings_sidebar['active_server_name'],
-                })
-                _point_names.add(r['server_name'])
-            if (
-                settings_sidebar['active_server_name']
-                and settings_sidebar['active_server_name'] not in _point_names
-            ):
-                _active_row = db.execute(
-                    '''WITH catalogue_country AS (
-                           SELECT name,
-                                  MAX(NULLIF(country_code, '')) AS country_code,
-                                  MAX(NULLIF(country, '')) AS country
-                           FROM gluetun_catalogue
-                           GROUP BY name
-                       )
-                       SELECT COALESCE(NULLIF(av.country_code, ''), cc.country_code) AS country_code,
-                              COALESCE(NULLIF(av.country, ''), cc.country) AS country,
-                              COUNT(DISTINCT st.id) AS uses
-                       FROM (SELECT ? AS name) active
-                       LEFT JOIN airvpn_snapshot av ON av.name = active.name
-                       LEFT JOIN catalogue_country cc ON cc.name = active.name
-                       LEFT JOIN speed_tests st ON st.server_name = active.name AND st.success = 1''',
-                    (settings_sidebar['active_server_name'],),
-                ).fetchone()
-                if _active_row:
-                    cc = (_active_row['country_code'] or '').lower()
-                    if cc in _country_coords:
-                        lat, lon = _country_coords[cc]
-                        _points.append({
-                            'server': settings_sidebar['active_server_name'],
-                            'uses': int(_active_row['uses'] or 0),
-                            'country': _active_row['country'] or cc.upper(),
-                            'country_code': cc,
-                            'lat': lat,
-                            'lon': lon,
-                            'active': True,
-                        })
-            settings_sidebar['map_points'] = _points
+            settings_sidebar['map_points'] = _server_map_points(
+                db, settings_sidebar['active_server_name']
+            )
     except Exception as exc:
         logger.debug('settings sidebar stats unavailable: %s', exc)
     return render_template(

--- a/app/templates/_server_map.html
+++ b/app/templates/_server_map.html
@@ -1,0 +1,282 @@
+{#
+   Shared interactive server world map.
+
+   Usage (import "with context" so t, url_for, session are available):
+     import '_server_map.html' as smap with context
+     smap.server_map(points, t.set_side_map_uses)   -> markup, once per map
+     smap.server_map_assets()                        -> style+script, once per page
+
+   points items: server, country, country_code, uses, lat, lon, provider,
+   provider_icon (url), active (bool).
+#}
+
+{% macro server_map(points, uses_label) %}
+<div class="server-map" data-uses-label="{{ uses_label }}">
+  <div class="smap-controls">
+    <button type="button" class="smap-zoom-in" aria-label="Zoom +" title="Zoom +"><i class="bi bi-plus-lg"></i></button>
+    <button type="button" class="smap-zoom-out" aria-label="Zoom −" title="Zoom −"><i class="bi bi-dash-lg"></i></button>
+    <button type="button" class="smap-zoom-reset" aria-label="Reset" title="Reset"><i class="bi bi-arrows-fullscreen"></i></button>
+  </div>
+  <svg viewBox="0 0 1000 520" role="img" aria-label="{{ t.set_side_world_map }}">
+    <g class="smap-viewport">
+      <image class="smap-base" href="{{ url_for('static', filename='world-map.svg') }}" x="0" y="0" width="1000" height="520"/>
+      {# non-active servers first #}
+      {% for p in points if not p.active %}
+        {% set x = ((p.lon + 180) / 360 * 1000) %}
+        {% set y = ((90 - p.lat) / 180 * 520) %}
+        {% set radius = 4 + ([p.uses, 18] | min) * 0.45 %}
+        <circle class="smap-pt smap-point"
+                cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}"
+                data-server="{{ p.server }}" data-country="{{ p.country }}" data-cc="{{ p.country_code }}"
+                data-uses="{{ p.uses }}" data-provider="{{ p.provider }}" data-picon="{{ p.provider_icon }}"></circle>
+      {% endfor %}
+      {# current server drawn last (on top), with a halo #}
+      {% for p in points if p.active %}
+        {% set x = ((p.lon + 180) / 360 * 1000) %}
+        {% set y = ((90 - p.lat) / 180 * 520) %}
+        {% set radius = [4 + ([p.uses, 18] | min) * 0.45, 6.5] | max %}
+        <circle class="smap-point-halo"
+                cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius + 3) }}"></circle>
+        <circle class="smap-pt smap-point-active"
+                cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}"
+                data-server="{{ p.server }}" data-country="{{ p.country }}" data-cc="{{ p.country_code }}"
+                data-uses="{{ p.uses }}" data-provider="{{ p.provider }}" data-picon="{{ p.provider_icon }}"></circle>
+      {% endfor %}
+    </g>
+  </svg>
+</div>
+<div class="small text-muted mt-2">
+  <span class="badge bg-info text-dark me-1">&nbsp;</span>{{ t.set_side_map_used }}
+  <span class="badge bg-warning text-dark ms-2 me-1">&nbsp;</span>{{ t.set_side_map_current }}
+</div>
+{% if not points %}
+<div class="small text-muted mt-2">{{ t.set_side_map_empty }}</div>
+{% endif %}
+{% endmacro %}
+
+
+{% macro server_map_assets() %}
+<style>
+  .server-map {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1.9;
+    border: 1px solid var(--bs-border-color);
+    border-radius: .45rem;
+    background:
+      radial-gradient(circle at 18% 48%, rgba(88,166,255,.16), transparent 18%),
+      radial-gradient(circle at 52% 42%, rgba(88,166,255,.14), transparent 21%),
+      radial-gradient(circle at 75% 55%, rgba(88,166,255,.14), transparent 18%),
+      linear-gradient(180deg, rgba(88,166,255,.08), rgba(88,166,255,.02));
+    overflow: hidden;
+    cursor: grab;
+    touch-action: none;
+  }
+  .server-map.smap-dragging { cursor: grabbing; }
+  .server-map svg { width: 100%; height: 100%; display: block; }
+  .smap-viewport { transform-box: view-box; }
+  .smap-base { opacity: .92; }
+  .smap-point {
+    fill: var(--bs-info);
+    opacity: .82;
+    stroke: var(--bs-body-bg);
+    stroke-width: 1.2;
+  }
+  .smap-point-active {
+    fill: var(--bs-warning);
+    opacity: 1;
+    stroke: var(--bs-body-color);
+    stroke-width: 1.6;
+  }
+  .smap-point-halo {
+    fill: var(--bs-warning);
+    opacity: .25;
+    stroke: none;
+  }
+  .smap-pt { cursor: pointer; }
+  .smap-controls {
+    position: absolute;
+    top: .4rem;
+    right: .4rem;
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    z-index: 2;
+  }
+  .smap-controls button {
+    width: 1.9rem;
+    height: 1.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    font-size: .8rem;
+    line-height: 1;
+    color: var(--bs-body-color);
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: .35rem;
+    opacity: .85;
+  }
+  .smap-controls button:hover { opacity: 1; }
+  .smap-tooltip {
+    position: fixed;
+    z-index: 1090;
+    pointer-events: none;
+    max-width: 230px;
+    padding: .4rem .55rem;
+    font-size: .76rem;
+    line-height: 1.3;
+    color: var(--bs-body-color);
+    background: var(--bs-body-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: .4rem;
+    box-shadow: 0 .35rem 1rem rgba(0,0,0,.35);
+  }
+  .smap-tooltip[hidden] { display: none; }
+  .smap-tip-name { font-weight: 600; margin-bottom: .1rem; }
+  .smap-tip-row { display: flex; align-items: center; gap: .3rem; }
+  .smap-tip-row img { width: 14px; height: 14px; object-fit: contain; border-radius: 2px; }
+  .smap-tip-prov { text-transform: capitalize; }
+</style>
+<script>
+(function () {
+  if (window.__smapInit) return;
+  window.__smapInit = true;
+
+  var MIN = 1, MAX = 8, VW = 1000, VH = 520;
+
+  var tip = document.createElement('div');
+  tip.className = 'smap-tooltip';
+  tip.hidden = true;
+  document.body.appendChild(tip);
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+  function flagEmoji(cc) {
+    if (!cc || cc.length !== 2) return '';
+    return cc.toUpperCase().replace(/./g, function (c) {
+      return String.fromCodePoint(0x1F1E6 - 65 + c.charCodeAt(0));
+    });
+  }
+  function showTip(ds, label, x, y) {
+    var flag = flagEmoji(ds.cc);
+    var html = '<div class="smap-tip-name">' + esc(ds.server) + '</div>';
+    html += '<div class="smap-tip-row">' + (flag ? flag + ' ' : '') + esc(ds.country) + '</div>';
+    if (ds.provider) {
+      html += '<div class="smap-tip-row">'
+        + (ds.picon ? '<img src="' + esc(ds.picon) + '" alt="">' : '')
+        + '<span class="smap-tip-prov">' + esc(ds.provider) + '</span></div>';
+    }
+    html += '<div class="smap-tip-row">' + esc(ds.uses) + ' ' + esc(label) + '</div>';
+    tip.innerHTML = html;
+    tip.hidden = false;
+    moveTip(x, y);
+  }
+  function moveTip(x, y) {
+    var pad = 14;
+    var w = tip.offsetWidth, h = tip.offsetHeight;
+    var px = x + pad, py = y + pad;
+    if (px + w > window.innerWidth)  px = x - w - pad;
+    if (py + h > window.innerHeight) py = y - h - pad;
+    tip.style.left = Math.max(4, px) + 'px';
+    tip.style.top  = Math.max(4, py) + 'px';
+  }
+  function hideTip() { tip.hidden = true; }
+
+  document.querySelectorAll('.server-map').forEach(function (map) {
+    var svg = map.querySelector('svg');
+    var vp  = map.querySelector('.smap-viewport');
+    if (!svg || !vp) return;
+    var label = map.getAttribute('data-uses-label') || '';
+    var s = 1, tx = 0, ty = 0;
+
+    function clamp() {
+      s = Math.min(MAX, Math.max(MIN, s));
+      tx = Math.min(0, Math.max((1 - s) * VW, tx));
+      ty = Math.min(0, Math.max((1 - s) * VH, ty));
+    }
+    function apply() {
+      clamp();
+      vp.setAttribute('transform', 'translate(' + tx.toFixed(2) + ' ' + ty.toFixed(2) + ') scale(' + s.toFixed(4) + ')');
+    }
+    function toView(clientX, clientY) {
+      var r = svg.getBoundingClientRect();
+      if (!r.width || !r.height) return null;
+      return { x: (clientX - r.left) / r.width * VW, y: (clientY - r.top) / r.height * VH };
+    }
+    function zoomAt(px, py, factor) {
+      var ns = Math.min(MAX, Math.max(MIN, s * factor));
+      if (ns === s) return;
+      // keep the world point under (px,py) fixed
+      tx = px - (px - tx) * (ns / s);
+      ty = py - (py - ty) * (ns / s);
+      s = ns;
+      apply();
+    }
+
+    svg.addEventListener('wheel', function (e) {
+      var pt = toView(e.clientX, e.clientY);
+      if (!pt) return;
+      e.preventDefault();
+      zoomAt(pt.x, pt.y, e.deltaY < 0 ? 1.2 : 1 / 1.2);
+    }, { passive: false });
+
+    var dragging = false, lastX = 0, lastY = 0, moved = false;
+    svg.addEventListener('pointerdown', function (e) {
+      if (e.button !== 0) return;
+      dragging = true; moved = false; lastX = e.clientX; lastY = e.clientY;
+      map.classList.add('smap-dragging');
+      svg.setPointerCapture(e.pointerId);
+    });
+    svg.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var r = svg.getBoundingClientRect();
+      if (!r.width) return;
+      var dx = (e.clientX - lastX) / r.width * VW;
+      var dy = (e.clientY - lastY) / r.height * VH;
+      if (Math.abs(e.clientX - lastX) + Math.abs(e.clientY - lastY) > 2) moved = true;
+      lastX = e.clientX; lastY = e.clientY;
+      tx += dx; ty += dy; apply();
+      hideTip();
+    });
+    function endDrag(e) {
+      if (!dragging) return;
+      dragging = false;
+      map.classList.remove('smap-dragging');
+      try { svg.releasePointerCapture(e.pointerId); } catch (_) {}
+    }
+    svg.addEventListener('pointerup', endDrag);
+    svg.addEventListener('pointercancel', endDrag);
+
+    // Tooltip on points
+    svg.addEventListener('mouseover', function (e) {
+      var pt = e.target.closest && e.target.closest('.smap-pt');
+      if (!pt) return;
+      showTip(pt.dataset, label, e.clientX, e.clientY);
+    });
+    svg.addEventListener('mousemove', function (e) {
+      if (tip.hidden || dragging) return;
+      var pt = e.target.closest && e.target.closest('.smap-pt');
+      if (pt) moveTip(e.clientX, e.clientY); else hideTip();
+    });
+    svg.addEventListener('mouseout', function (e) {
+      var pt = e.target.closest && e.target.closest('.smap-pt');
+      if (pt) hideTip();
+    });
+
+    var bi = map.querySelector('.smap-zoom-in');
+    var bo = map.querySelector('.smap-zoom-out');
+    var br = map.querySelector('.smap-zoom-reset');
+    if (bi) bi.addEventListener('click', function () { zoomAt(VW / 2, VH / 2, 1.4); });
+    if (bo) bo.addEventListener('click', function () { zoomAt(VW / 2, VH / 2, 1 / 1.4); });
+    if (br) br.addEventListener('click', function () { s = 1; tx = 0; ty = 0; apply(); });
+
+    apply();
+  });
+})();
+</script>
+{% endmacro %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,4 +1,5 @@
 ﻿﻿{% extends 'base.html' %}
+{% import '_server_map.html' as smap with context %}
 {% block title %}{{ t.nav_dashboard }} - Gluetun Companion{% endblock %}
 
 {% block content %}
@@ -82,37 +83,7 @@
     .active-server-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   }
   .dash-fixed-card { min-height: 245px; }
-  .dash-world-map {
-    width: 100%;
-    aspect-ratio: 1.9;
-    border: 1px solid var(--bs-border-color);
-    border-radius: .45rem;
-    background:
-      radial-gradient(circle at 18% 48%, rgba(88,166,255,.16), transparent 18%),
-      radial-gradient(circle at 52% 42%, rgba(88,166,255,.14), transparent 21%),
-      radial-gradient(circle at 75% 55%, rgba(88,166,255,.14), transparent 18%),
-      linear-gradient(180deg, rgba(88,166,255,.08), rgba(88,166,255,.02));
-    overflow: hidden;
-  }
-  .dash-world-map svg { width: 100%; height: 100%; display: block; }
-  .dash-map-base { opacity: .92; }
-  .dash-map-point {
-    fill: var(--bs-info);
-    opacity: .82;
-    stroke: var(--bs-body-bg);
-    stroke-width: 1.2;
-  }
-  .dash-map-point-active {
-    fill: var(--bs-warning);
-    opacity: 1;
-    stroke: var(--bs-body-color);
-    stroke-width: 1.6;
-  }
-  .dash-map-point-halo {
-    fill: var(--bs-warning);
-    opacity: .25;
-    stroke: none;
-  }
+  /* server map styles: app/templates/_server_map.html */
   /* obs-* styles moved to base.html */
   .pool-activity-scroll {
     max-height: 34rem;
@@ -502,40 +473,7 @@
       <div class="fw-semibold mb-2" style="font-size:.9rem">
         <i class="bi bi-globe-europe-africa text-info"></i> {{ t.dash_map_title }}
       </div>
-      <div class="dash-world-map">
-        <svg viewBox="0 0 1000 520" role="img" aria-label="{{ t.dash_map_title }}">
-          <image class="dash-map-base" href="{{ url_for('static', filename='world-map.svg') }}" x="0" y="0" width="1000" height="520"/>
-          {# non-active servers first #}
-          {% for p in dashboard_map_points if not p.active %}
-            {% set x = ((p.lon + 180) / 360 * 1000) %}
-            {% set y = ((90 - p.lat) / 180 * 520) %}
-            {% set radius = 4 + ([p.uses, 18] | min) * 0.45 %}
-            <circle class="dash-map-point"
-                    cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
-              <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
-            </circle>
-          {% endfor %}
-          {# current server drawn last, with a halo, so it is never hidden by overlapping points #}
-          {% for p in dashboard_map_points if p.active %}
-            {% set x = ((p.lon + 180) / 360 * 1000) %}
-            {% set y = ((90 - p.lat) / 180 * 520) %}
-            {% set radius = [4 + ([p.uses, 18] | min) * 0.45, 6.5] | max %}
-            <circle class="dash-map-point-halo"
-                    cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius + 3) }}"/>
-            <circle class="dash-map-point-active"
-                    cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
-              <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
-            </circle>
-          {% endfor %}
-        </svg>
-      </div>
-      <div class="small text-muted mt-2">
-        <span class="badge bg-info text-dark me-1">&nbsp;</span>{{ t.set_side_map_used }}
-        <span class="badge bg-warning text-dark ms-2 me-1">&nbsp;</span>{{ t.set_side_map_current }}
-      </div>
-      {% if not dashboard_map_points %}
-      <div class="small text-muted mt-2">{{ t.set_side_map_empty }}</div>
-      {% endif %}
+      {{ smap.server_map(dashboard_map_points, t.set_side_map_uses) }}
       {% endif %}
     </div>
   </div>
@@ -957,6 +895,7 @@
 {% endblock %}
 
 {% block scripts %}
+{{ smap.server_map_assets() }}
 {% set _bench_method = 'sidecar' if sidecar_mode == '1' else 'proxy' %}
 <script>
 const _msgRunning  = '{{ t.dash_running }}';

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,4 +1,5 @@
 ﻿{% extends 'base.html' %}
+{% import '_server_map.html' as smap with context %}
 {% block title %}{{ t.set_title }} – Gluetun Companion{% endblock %}
 
 {% block content %}
@@ -123,48 +124,7 @@
     padding-left: .75rem;
     color: var(--bs-secondary-color);
   }
-  .settings-world-map {
-    width: 100%;
-    aspect-ratio: 1.9;
-    border: 1px solid var(--bs-border-color);
-    border-radius: .45rem;
-    background:
-      radial-gradient(circle at 18% 48%, rgba(88,166,255,.16), transparent 18%),
-      radial-gradient(circle at 52% 42%, rgba(88,166,255,.14), transparent 21%),
-      radial-gradient(circle at 75% 55%, rgba(88,166,255,.14), transparent 18%),
-      linear-gradient(180deg, rgba(88,166,255,.08), rgba(88,166,255,.02));
-    overflow: hidden;
-  }
-  .settings-world-map svg {
-    width: 100%;
-    height: 100%;
-    display: block;
-  }
-  .settings-map-land {
-    fill: rgba(125, 133, 144, .28);
-    stroke: rgba(125, 133, 144, .35);
-    stroke-width: .7;
-  }
-  .settings-map-base {
-    opacity: .92;
-  }
-  .settings-map-point {
-    fill: var(--bs-info);
-    opacity: .82;
-    stroke: var(--bs-body-bg);
-    stroke-width: 1.2;
-  }
-  .settings-map-point-active {
-    fill: var(--bs-warning);
-    opacity: 1;
-    stroke: var(--bs-body-color);
-    stroke-width: 1.6;
-  }
-  .settings-map-point-halo {
-    fill: var(--bs-warning);
-    opacity: .25;
-    stroke: none;
-  }
+  /* server map styles: app/templates/_server_map.html */
   .settings-readme-card {
     max-height: 32rem;
     overflow: auto;
@@ -395,40 +355,7 @@
   {% macro settings_world_map() %}
   <div class="settings-help-card">
     <h6><i class="bi bi-globe-europe-africa me-1"></i>{{ t.set_side_world_map }}</h6>
-    <div class="settings-world-map">
-      <svg viewBox="0 0 1000 520" role="img" aria-label="{{ t.set_side_world_map }}">
-        <image class="settings-map-base" href="{{ url_for('static', filename='world-map.svg') }}" x="0" y="0" width="1000" height="520"/>
-        {# non-active servers first #}
-        {% for p in settings_sidebar.map_points if not p.active %}
-          {% set x = ((p.lon + 180) / 360 * 1000) %}
-          {% set y = ((90 - p.lat) / 180 * 520) %}
-          {% set radius = 4 + ([p.uses, 18] | min) * 0.45 %}
-          <circle class="settings-map-point"
-                  cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
-            <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
-          </circle>
-        {% endfor %}
-        {# current server drawn last, with a halo, so it is never hidden by overlapping points #}
-        {% for p in settings_sidebar.map_points if p.active %}
-          {% set x = ((p.lon + 180) / 360 * 1000) %}
-          {% set y = ((90 - p.lat) / 180 * 520) %}
-          {% set radius = [4 + ([p.uses, 18] | min) * 0.45, 6.5] | max %}
-          <circle class="settings-map-point-halo"
-                  cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius + 3) }}"/>
-          <circle class="settings-map-point-active"
-                  cx="{{ '%.1f'|format(x) }}" cy="{{ '%.1f'|format(y) }}" r="{{ '%.1f'|format(radius) }}">
-            <title>{{ p.server }} · {{ p.country }} · {{ p.uses }} {{ t.set_side_map_uses }}</title>
-          </circle>
-        {% endfor %}
-      </svg>
-    </div>
-    <div class="small text-muted mt-2">
-      <span class="badge bg-info text-dark me-1">&nbsp;</span>{{ t.set_side_map_used }}
-      <span class="badge bg-warning text-dark ms-2 me-1">&nbsp;</span>{{ t.set_side_map_current }}
-    </div>
-    {% if not settings_sidebar.map_points %}
-      <div class="text-muted mt-2">{{ t.set_side_map_empty }}</div>
-    {% endif %}
+    {{ smap.server_map(settings_sidebar.map_points, t.set_side_map_uses) }}
   </div>
   {% endmacro %}
 
@@ -3142,6 +3069,7 @@ if (document.readyState === 'loading') {
 {% endblock %}
 
 {% block scripts %}
+{{ smap.server_map_assets() }}
 {% set _bench_method = 'sidecar' if cfg.sidecar_mode == '1' else 'proxy' %}
 <script>
 // ── Settings tabs + AJAX saves ───────────────────────────────────────────


### PR DESCRIPTION
## Objectif

Améliorer la **Carte des serveurs** (sur `/` et dans `/settings`) avec trois fonctionnalités :

1. **Tooltip riche** au survol d'un point : nom du serveur, drapeau + pays, logo + nom du fournisseur VPN, nombre de tests réalisés.
2. **Zoom et déplacement** directement sur la carte : molette pour zoomer, glisser pour déplacer, plus des boutons +/− et reset.
3. **Plus d'historique** : 30 → 60 serveurs les plus testés (toujours plus le serveur courant).

## Implémentation

**Nouveau partial partagé `app/templates/_server_map.html`**
- Macro `server_map(points, uses_label)` : markup de la carte (SVG zoomable, points avec attributs `data-*`, légende, message vide).
- Macro `server_map_assets()` : CSS + JS génériques (pan/zoom + tooltip), à inclure une fois par page. Le JS opère sur tout conteneur `.server-map` présent (gère donc les 7 instances de la page Paramètres).

**Templates**
- `dashboard.html` et `settings.html` importent le partial (`with context`) et appellent les macros. Les blocs SVG et le CSS de carte dupliqués sont supprimés.

**Serveur (`app/routes.py`)**
- `_server_map_points` enrichit chaque point avec `provider` (profil VPN explicite, sinon AirVPN si présent dans le snapshot) et `provider_icon` (URL via le helper `_provider_icon_url`). Limite passée à 60.
- La route `/settings` réutilise `_server_map_points` : suppression d'un bloc de calcul dupliqué (~75 lignes) et du dictionnaire de coordonnées local, identique à celui du module.

## Vérifications

- `py_compile` sur `routes.py` : OK
- Rendu Jinja du macro `server_map` avec données factices (actif + non actif, avec/sans fournisseur) : attributs `data-*`, halo, points actifs/inactifs, légende et cas vide présents
- Compilation Jinja de `dashboard.html` et `settings.html` (filtres custom stubbés) : OK
- Suite de tests existante : 15 passés
- Aucune référence orpheline aux anciennes classes (`dash-world-map`, `settings-map-*`, `_country_coords`)

## Note

La carte est rendue côté serveur au chargement de la page : le serveur courant (point jaune) reflète l'état réel à chaque rechargement, pas en direct sans recharger.
