### PR TITLE
fix: corriger le chemin des logos de fournisseurs dans le catalogue Gluetun

### DIFF
--- a/app/templates/servers.html
+++ b/app/templates/servers.html
@@ -1593,7 +1593,8 @@ function _catCanAdd(provider) {
 
 // Provider icon helper: bundled SVG, else server-side cached favicon route.
 // Keep in sync with PROVIDER_SVG_FILES / PROVIDER_FAVICON_DOMAINS in routes.py.
-const _STATIC_PROVIDERS = '/static/providers/';
+// Path derived from Flask's static route so it follows static_url_path.
+const _STATIC_PROVIDERS = '{{ url_for("static", filename="providers/") }}';
 const _SVG_PROVIDERS = new Set([
   'airvpn','cyberghost','expressvpn','fastestvpn',
   'mullvad','nordvpn','private internet access','protonvpn',


### PR DESCRIPTION
## Problème

Après le déplacement des logos vers `assets/providers/`, des logos manquaient encore dans le **Catalogue Gluetun** (page `/servers`). En cause : le constructeur d'icônes **côté JS** du catalogue utilisait un chemin codé en dur `/static/providers/`, alors que Flask sert le statique depuis `/assets/`. Les `<img>` du catalogue pointaient donc vers des URLs inexistantes (404).

Le tableau principal de `/servers` n'était pas concerné : il passe par le helper serveur `server_provider_icon` (déjà corrigé).

## Correction

Dans `app/templates/servers.html`, le préfixe est désormais dérivé de la route statique de Flask :

```js
const _STATIC_PROVIDERS = '{{ url_for("static", filename="providers/") }}';  // -> /assets/providers/
```

Plus aucun chemin `/static/` codé en dur dans les templates.

## Vérifications

- Compilation Jinja de `servers.html` : OK
- Valeur rendue : `_STATIC_PROVIDERS = /assets/providers/`
- Les SVG correspondants sont servis en 200 (vérifié au commit précédent)
