### PR TITLE
fix: unifier la langue UI et notifications (source de vérité ui_lang)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from flask import Flask, session
 from markupsafe import Markup
 from .database import init_db
-from .i18n import get_translations
+from .i18n import get_translations, get_lang
 
 _cleanup_hooks_registered = False
 
@@ -231,7 +231,7 @@ def create_app():
         except (ValueError, TypeError):
             return ''
 
-        fr = session.get('lang', 'fr') == 'fr'
+        fr = get_lang() == 'fr'
         future = delta > 0
         secs = abs(int(delta))
         if secs < 60:
@@ -284,7 +284,7 @@ def create_app():
 
     @app.context_processor
     def inject_i18n():
-        lang = session.get('lang', 'fr')
+        lang = get_lang()
         return {'t': get_translations(lang), 'lang': lang}
 
     @app.context_processor
@@ -300,7 +300,7 @@ def create_app():
             _has_airvpn = False
         try:
             from .dns_path import get_dns_path
-            _dns_path = get_dns_path(app.config['GLUETUN_CONTAINER'], session.get('lang', 'fr'))
+            _dns_path = get_dns_path(app.config['GLUETUN_CONTAINER'], get_lang())
         except Exception:
             _dns_path = {
                 'ok': False, 'intermediary': {}, 'intermediary_value': '',

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -2029,10 +2029,34 @@ def get_translations(lang: str) -> dict[str, str]:
     return TRANSLATIONS.get(lang, TRANSLATIONS['fr'])
 
 
+def get_lang() -> str:
+    """Resolve the active UI language.
+
+    The persisted ``ui_lang`` setting is the source of truth (it is what
+    background tasks and notifications use).  An explicit per-session choice
+    takes precedence so a user can preview the other language without changing
+    the saved preference; when the session has no explicit choice (e.g. after
+    logout or cookie expiry) we fall back to ``ui_lang`` so the UI and the
+    notifications never disagree.  French is the final default.
+    """
+    try:
+        from flask import has_request_context, session
+        if has_request_context():
+            sl = session.get('lang')
+            if sl:
+                return sl
+    except Exception:
+        pass
+    try:
+        from .database import get_setting
+        return get_setting('ui_lang', 'fr')
+    except Exception:
+        return 'fr'
+
+
 def get_t() -> dict[str, str]:
-    """Return translations for the current request's language (reads Flask session)."""
-    from flask import session
-    return get_translations(session.get('lang', 'fr'))
+    """Return translations for the current request's active language."""
+    return get_translations(get_lang())
 
 
 def flash_t(key: str, category: str = 'info', **kwargs) -> None:

--- a/app/routes.py
+++ b/app/routes.py
@@ -667,9 +667,10 @@ def dashboard():
 @login_required
 def api_dns_status():
     from .dns_path import get_dns_path
+    from .i18n import get_lang
     return jsonify(get_dns_path(
         current_app.config['GLUETUN_CONTAINER'],
-        session.get('lang', 'fr'),
+        get_lang(),
         force=True,
     ))
 


### PR DESCRIPTION
## Problème

Notification de bascule reçue en **anglais** alors que l'interface est en français.

Cause : deux sources de langue distinctes.
- **UI** : `session['lang']` (cookie, défaut `fr`).
- **Notifications / tâches de fond** : réglage persistant `ui_lang` (un thread d'arrière-plan n'a pas accès à la session).

Le sélecteur `/lang/<code>` écrit bien les deux. Mais après un **logout** (`session.clear()`) ou l'expiration du cookie, `session['lang']` disparaît : l'UI retombe sur le défaut `fr`, tandis que `ui_lang` conserve le dernier choix persistant (ici `en`). D'où une interface FR mais des notifications EN.

À noter : `get_translations()` ne fait aucun repli clé-par-clé — une notification entièrement en EN prouve que `lang='en'` a bien été lu côté persistant.

## Correction

Ajout d'un résolveur `get_lang()` dans `app/i18n.py` :
1. choix explicite de session s'il existe (permet de prévisualiser l'autre langue) ;
2. sinon le réglage persistant `ui_lang` ;
3. sinon `fr`.

Les lectures UI passent désormais par `get_lang()` (`get_t`, le context processor `inject_i18n`, le filtre timeago, le DNS path). `ui_lang` devient la **source de vérité** : l'interface et les notifications ne peuvent plus diverger.

## Vérifications

- `py_compile` (i18n, __init__, routes) : OK
- Suite de tests : 15 passés
- Test fonctionnel de `get_lang()` hors contexte de requête :
  - aucun réglage → `fr`
  - `ui_lang=en` → `en`
  - `ui_lang=fr` → `fr`

## Note pour l'utilisateur

Après déploiement, l'interface reflétera le réglage **persistant** `ui_lang`. Si celui-ci vaut `en` (cas à l'origine du ticket), l'UI s'affichera en EN : il suffit de re-sélectionner **FR** une fois dans le sélecteur de langue — le choix est alors persisté et s'applique partout (UI + notifications).
