### PR TITLE
fix: arrêter le cycle en cours quand on désactive son mode (benchmark/observation)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1742,6 +1742,21 @@ def settings():
                     set_setting(_key, _default)
             observation_enabled = bool(request.form.get('continuous_observation'))
             set_setting('continuous_observation', '1' if observation_enabled else '0')
+            # If the user just disabled a mode whose cycle is currently running,
+            # abort it now so "disabled" halts the current activity instead of
+            # only preventing future cycles.  Stopping an observation cycle also
+            # restores the original server (proxy-fallback revert at cycle end).
+            if get_setting('benchmark_running', '0') == '1':
+                _run_mode = get_setting('benchmark_mode', '')
+                _eff_auto_bm = auto_bm and not active_auto_pools
+                if ((_run_mode == 'observation' and not observation_enabled)
+                        or (_run_mode == 'benchmark' and not _eff_auto_bm)):
+                    from .scheduler import request_stop
+                    request_stop()
+                    logger.info(
+                        'Settings: %s cycle running but mode disabled — requesting stop',
+                        _run_mode,
+                    )
             # Bench pre-filters
             _types_selected = request.form.getlist('bench_include_types')
             _valid_types = {'name', 'country', 'city', 'region', 'hostname'}


### PR DESCRIPTION
## Problème signalé

Malgré la désactivation de « cycle de benchmark automatique » et « observation continue », l'application continuait de tester des serveurs (« Benchmark Test en cours : … 56% »), et le serveur VPN changeait plusieurs fois.

## Analyse

Trois mécanismes pilotent l'activité, et ils sont **indépendants** :

1. **Cycle de benchmark planifié** — `run_benchmark`, gardé par `auto_benchmark`.
2. **Observation continue pyramidale** — gardée par `continuous_observation`.
3. **Pools de rotation auto** (`enabled=1, auto_rotate=1`) — changent le serveur tout seuls, indépendamment de « Bascule automatique », et **forcent même `auto_benchmark` à OFF** dans l'UI tout en continuant à tourner.

Le défaut corrigé ici concerne 1 et 2 : décocher l'option ne faisait que mettre le réglage à jour ; **un cycle déjà en cours continuait jusqu'au bout**. C'est ce qui faisait persister « … 56% ~1h38min ». Et pendant un cycle, le repli HTTP proxy (quand le sidecar échoue) bascule temporairement le Gluetun de production sur le serveur testé — d'où des changements de serveur visibles.

## Correction

À l'enregistrement de **Planification** (`save_planning`), si un cycle dont le mode vient d'être désactivé est en cours, on appelle `request_stop()` :
- `benchmark_mode == 'observation'` et observation décochée → arrêt ;
- `benchmark_mode == 'benchmark'` et benchmark auto décoché (et pas de pool auto actif) → arrêt.

Pour l'observation, l'arrêt déclenche aussi la **restauration du serveur d'origine** (repli proxy restauré en fin de cycle, cf. correctif précédent). « Désactivé » stoppe donc l'activité courante, pas seulement les cycles futurs.

Les pools de rotation (mécanisme 3) ne sont volontairement pas touchés : c'est une fonctionnalité à part entière. Pour stopper des changements dus à un pool, il faut désactiver le pool.

## Vérifications

- `py_compile` : OK
- Suite de tests : 15 passés
