### PR TITLE
perf: pull l'image sidecar une fois par cycle et la garder en cache

### DIFF
--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -1191,10 +1191,48 @@ def create_test_gluetun(
         return False, str(exc)
 
 
-def create_speed_sidecar(sidecar_image: str, token: str = '') -> tuple[bool, str | None]:
+def pull_sidecar_image(sidecar_image: str) -> bool:
+    """Best-effort pull of the sidecar image (once per benchmark cycle).
+
+    Returns True if the image is available afterwards (freshly pulled OR already
+    cached).  A failed pull is non-fatal: as long as a cached copy exists the
+    cycle can keep testing, which makes benchmarks resilient to transient
+    registry/DNS failures instead of falling back to the proxy on every server.
     """
-    Pull the latest sidecar image, then create the container in the test Gluetun
-    network namespace. Pulling every time ensures we always run the latest version.
+    try:
+        client = docker.from_env()
+        try:
+            logger.info('Pulling sidecar image: %s', sidecar_image)
+            client.images.pull(sidecar_image)
+            logger.info('Sidecar image up to date: %s', sidecar_image)
+            return True
+        except Exception as exc:
+            # Pull failed (e.g. DNS/registry hiccup) — fall back to a cached copy.
+            try:
+                client.images.get(sidecar_image)
+                logger.warning(
+                    'Sidecar image pull failed (%s) — using cached image', exc,
+                )
+                return True
+            except Exception:
+                logger.error('Sidecar image pull failed and no cached copy: %s', exc)
+                return False
+    except Exception as exc:
+        logger.error('pull_sidecar_image %s: %s', sidecar_image, exc)
+        return False
+
+
+def create_speed_sidecar(
+    sidecar_image: str, token: str = '', pull: bool = True,
+) -> tuple[bool, str | None]:
+    """
+    Create the sidecar container in the test Gluetun network namespace.
+
+    *pull* controls registry access: with ``pull=False`` the locally cached
+    image is reused (pulled only if missing).  Per-server tests pass
+    ``pull=False`` so the image is fetched once per cycle via
+    ``pull_sidecar_image`` instead of before every server — this avoids
+    hammering the registry/DNS and keeps tests resilient to transient failures.
 
     *token* is passed as SIDECAR_SECRET env var so the sidecar requires it on
     every request.  Generate with secrets.token_hex(32) in the caller.
@@ -1202,9 +1240,17 @@ def create_speed_sidecar(sidecar_image: str, token: str = '') -> tuple[bool, str
     try:
         client = docker.from_env()
 
-        logger.info('Pulling sidecar image: %s', sidecar_image)
-        client.images.pull(sidecar_image)
-        logger.info('Sidecar image up to date: %s', sidecar_image)
+        if pull:
+            logger.info('Pulling sidecar image: %s', sidecar_image)
+            client.images.pull(sidecar_image)
+            logger.info('Sidecar image up to date: %s', sidecar_image)
+        else:
+            # Reuse the cached image; pull only if it is missing locally.
+            try:
+                client.images.get(sidecar_image)
+            except docker.errors.ImageNotFound:
+                logger.info('Sidecar image not cached — pulling: %s', sidecar_image)
+                client.images.pull(sidecar_image)
 
         _remove_container(client, _SIDECAR_NAME, kill_first=True)
 
@@ -1373,16 +1419,18 @@ def run_sidecar_ping_test(
 
 
 def cleanup_test_containers(sidecar_image: str | None = None) -> None:
-    """Stop and remove the test Gluetun and sidecar containers, then delete the sidecar image."""
+    """Stop and remove the test Gluetun and sidecar containers.
+
+    The sidecar image is intentionally kept cached between server tests and
+    cycles: it is pulled once per benchmark cycle (see ``pull_sidecar_image``),
+    not per server.  Deleting and re-pulling it for every server hammered the
+    registry/DNS and made each test fail on a transient DNS hiccup.  The
+    *sidecar_image* argument is kept for backward compatibility but no longer
+    triggers image removal.
+    """
     client = docker.from_env()
     for name in [_SIDECAR_NAME, _TEST_GLUETUN_NAME]:
         _remove_container(client, name, kill_first=True)
-    if sidecar_image:
-        try:
-            client.images.remove(sidecar_image, force=True)
-            logger.info('Sidecar image removed: %s', sidecar_image)
-        except Exception as exc:
-            logger.debug('Could not remove sidecar image: %s', exc)
     logger.info('Test containers cleaned up')
 
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -361,8 +361,10 @@ def _test_one_server_sidecar(
         if not ok:
             raise RuntimeError(f'Test Gluetun creation failed: {err}')
 
-        # Step 2 — attach sidecar to test Gluetun's network namespace
-        ok, err = create_speed_sidecar(sidecar_image, token=token)
+        # Step 2 — attach sidecar to test Gluetun's network namespace.
+        # Use the cached image (pulled once per cycle by pull_sidecar_image),
+        # not a per-server pull, to avoid hammering the registry/DNS.
+        ok, err = create_speed_sidecar(sidecar_image, token=token, pull=False)
         if not ok:
             raise RuntimeError(f'Speed sidecar creation failed: {err}')
 
@@ -494,6 +496,8 @@ def _test_one_server_sidecar(
             settle = max(0, int(_sgs('sidecar_disconnect_wait_seconds', '180') or '180'))
         except ValueError:
             settle = 180
+        if _stop_event.is_set():
+            settle = 0   # user asked to stop — don't idle-wait after the last test
         if settle:
             logger.info(
                 '  %s: waiting %ds after sidecar cleanup so provider sessions can close',
@@ -1474,6 +1478,14 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
         # leaves it there — only meaningful in sidecar mode, since proxy mode is
         # expected to move Gluetun on its own.
         _orig_prod_filters = get_current_filters(container) if sidecar_mode else None
+
+        # Pull the sidecar image once for the whole cycle (best-effort).  Per-server
+        # tests then reuse the cached image instead of pulling (and deleting) it for
+        # every server, which hammered the registry/DNS and made each test fail on a
+        # transient DNS hiccup (→ proxy fallback → unwanted server switch).
+        if sidecar_mode and servers:
+            from .gluetun import pull_sidecar_image
+            pull_sidecar_image(sidecar_image)
 
         for idx, row in enumerate(servers, start=1):
             if _stop_event.is_set():


### PR DESCRIPTION
## Contexte (diagnostiqué sur le serveur de l'utilisateur)

Les logs montraient, pour **chaque** serveur d'un cycle :
`Pulling sidecar image` → test → `Sidecar image removed`. Soit ~55 pull + suppression par cycle.

Deux conséquences :
1. **DNS/registre martelés** : à chaque hoquet de résolution `ghcr.io` (`lookup ghcr.io on 127.0.0.53:53: server misbehaving`), le pull échouait → le test sidecar échouait → repli HTTP proxy → **bascule du serveur de production**.
2. **Cycles très longs** : pull + extraction répétés ~55 fois.

## Correction

- `pull_sidecar_image()` : pull **une seule fois par cycle**, en **best-effort** — si le pull échoue mais qu'une copie est en cache, le cycle continue (tests résilients aux pannes DNS transitoires au lieu de basculer le serveur).
- `create_speed_sidecar(pull=False)` pour les tests par serveur : réutilise l'image en cache (pull seulement si absente).
- `cleanup_test_containers` ne **supprime plus** l'image (cache conservé entre serveurs et cycles).
- Le délai `sidecar_disconnect_wait_seconds` est ignoré quand un **arrêt** est demandé (stop immédiat, plus d'attente inutile).

Effets : forte baisse de la charge DNS, cycles plus courts, et fin des bascules de serveur dues aux échecs de pull.

## Vérifications

- `py_compile` (gluetun, scheduler) : OK
- API : `pull_sidecar_image` présent, `create_speed_sidecar(pull=...)` ajouté
- Suite de tests : 15 passés
