### PR TITLE
docs: cache d'image sidecar et réglage du délai de cycle

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -416,18 +416,20 @@ Benchmark parameters (streams, duration, warm-up, retry…) are configured in th
 ```
 Benchmark cycle (every X hours)
   ├─ "Pause bench" containers stopped (torrents, Usenet…)
+  ├─ Pull ghcr.io/aerya/gluetun-companion-sidecar:latest
+  │   (once per cycle, image kept cached; best-effort: falls back to the
+  │    cached image if the registry/DNS is momentarily unavailable)
   └─ For each enabled server:
-       1. Pull ghcr.io/aerya/gluetun-companion-sidecar:latest
-       2. Start gluetun-companion-test
+       1. Start gluetun-companion-test
           (clone of your Gluetun, configured for the target server)
-       3. Start gluetun-companion-sidecar
+       2. Start gluetun-companion-sidecar
           (network_mode: container:gluetun-companion-test)
-       4. Wait for VPN via /health polling (configurable timeout)
-       5. Speed test inside the VPN tunnel (configurable engine):
+       3. Wait for VPN via /health polling (configurable timeout)
+       4. Speed test inside the VPN tunnel (configurable engine):
           - Dual (default): Ookla + librespeed in parallel, iperf3 as fallback
           - Ookla only, librespeed only, or iperf3 only
           → DL, UL, latency recorded per source
-       6. Stop + remove containers and sidecar image
+       5. Stop + remove the test containers (sidecar image kept cached)
        → Auto-retry on failure, global timeout per server
        → Auto-disable after N consecutive failures
   └─ Weighted score (65% current cycle + 35% exponential history)
@@ -448,7 +450,8 @@ Benchmark cycle (every X hours)
 - HTTP proxy fallback if sidecar fails entirely (disabled by default)
 
 > ⚠ **Simultaneous connection**: sidecar mode uses one extra VPN connection slot for the entire benchmark duration. Check your provider's limits (AirVPN: 3–5 depending on plan).
-> Companion runs sidecar tests one at a time and waits 180 s by default after container cleanup (`sidecar_disconnect_wait_seconds`) so the provider can close the VPN session before the next server starts.
+> Companion runs sidecar tests one at a time and waits 180 s by default after container cleanup (`sidecar_disconnect_wait_seconds`) so the provider can close the VPN session before the next server starts. **This is the main driver of cycle duration**: with N servers a cycle takes at least N × this delay. If your plan allows several simultaneous connections (AirVPN: 3–5), lower it significantly (60 s or less) in **Settings → Measure** to shorten cycles; raise it if you see "too many connections" errors.
+> The sidecar image is pulled **once per cycle** then reused from cache: less load on the registry/DNS, and a test no longer fails (nor switches the server) on a transient DNS hiccup.
 
 ### HTTP proxy mode (optional)
 

--- a/README.md
+++ b/README.md
@@ -415,18 +415,20 @@ Les paramètres de benchmark (flux, durée, warm-up, retry…) se configurent da
 ```
 Cycle de benchmark (toutes les X heures)
   ├─ Containers "pause bench" stoppés (torrents, Usenet…)
+  ├─ Pull ghcr.io/aerya/gluetun-companion-sidecar:latest
+  │   (une seule fois par cycle, image conservée en cache ; best-effort :
+  │    repli sur le cache si le registre/DNS est momentanément indisponible)
   └─ Pour chaque serveur activé :
-       1. Pull ghcr.io/aerya/gluetun-companion-sidecar:latest
-       2. Lancement de gluetun-companion-test
+       1. Lancement de gluetun-companion-test
           (copie de votre Gluetun, configuré sur le serveur cible)
-       3. Lancement de gluetun-companion-sidecar
+       2. Lancement de gluetun-companion-sidecar
           (network_mode: container:gluetun-companion-test)
-       4. Attente connexion VPN via /health polling (timeout configurable)
-       5. Test de débit dans le tunnel VPN (moteur configurable) :
+       3. Attente connexion VPN via /health polling (timeout configurable)
+       4. Test de débit dans le tunnel VPN (moteur configurable) :
           - Dual (défaut) : Ookla + librespeed en parallèle, iperf3 en fallback
           - Ookla seul, librespeed seul, ou iperf3 seul
           → DL, UL, latence enregistrés par source
-       6. Stop + suppression des containers et de l'image sidecar
+       5. Stop + suppression des containers de test (image sidecar conservée)
        → Retry automatique si échec, timeout global par serveur
        → Auto-désactivation si N échecs consécutifs
   └─ Score pondéré (65 % cycle actuel + 35 % historique exponentiel)
@@ -447,7 +449,8 @@ Cycle de benchmark (toutes les X heures)
 - Proxy HTTP en fallback si le sidecar échoue complètement (désactivé par défaut)
 
 > ⚠ **Connexion simultanée** : le mode sidecar consomme un slot VPN supplémentaire pendant toute la durée du benchmark. Vérifiez les limites de votre fournisseur (AirVPN : 3–5 selon l'abonnement).
-> Companion enchaîne les tests sidecar un par un et attend par défaut 180 s après le nettoyage des containers (`sidecar_disconnect_wait_seconds`) pour laisser le fournisseur fermer la session VPN avant le serveur suivant.
+> Companion enchaîne les tests sidecar un par un et attend par défaut 180 s après le nettoyage des containers (`sidecar_disconnect_wait_seconds`) pour laisser le fournisseur fermer la session VPN avant le serveur suivant. **C'est le principal facteur de durée d'un cycle** : avec N serveurs, le cycle dure au moins N × ce délai. Si votre abonnement autorise plusieurs connexions simultanées (AirVPN : 3–5), réduisez-le nettement (60 s, voire moins) dans **Paramètres → Mesurer** pour raccourcir les cycles ; augmentez-le si vous voyez des erreurs « too many connections ».
+> L'image sidecar n'est tirée qu'**une fois par cycle** puis réutilisée depuis le cache : moins de charge sur le registre/DNS, et un test n'échoue plus (ni ne bascule le serveur) sur un hoquet DNS passager.
 
 ### Mode Proxy HTTP (optionnel)
 


### PR DESCRIPTION
## Objectif

Aligner les READMEs (FR/EN) sur le nouveau comportement (PR #49) et donner un conseil de réglage utile.

## Modifications

- **Flux mode Sidecar** : le pull de l'image sidecar passe au niveau du cycle (« une seule fois par cycle, image conservée en cache ; best-effort : repli sur le cache si registre/DNS indisponible »). L'étape par serveur ne pull plus et ne supprime plus l'image (« Stop + suppression des containers de test, image sidecar conservée »).
- **Note `sidecar_disconnect_wait_seconds`** : précise que c'est le principal facteur de durée d'un cycle (N serveurs × délai) et conseille de le baisser (60 s ou moins) selon le nombre de connexions simultanées autorisées par le fournisseur. Ajoute la mention du pull unique par cycle et de la résilience aux hoquets DNS.

Le défaut logiciel (180 s) est conservé dans la doc ; seule la recommandation de réglage est ajoutée.

## Vérifications

- Modifications limitées aux deux READMEs (diagramme + note), pas de changement de code.
