### PR TITLE
Corriger la détection des tags Docker CLI pour Trivy

### DIFF
--- a/.github/scripts/trivy_autofix.py
+++ b/.github/scripts/trivy_autofix.py
@@ -76,24 +76,36 @@ def _hub_tags(image: str, name_filter: str) -> list[str]:
         return []
 
 
+def _docker_cli_version(tag: str) -> tuple[int, int, int] | None:
+    """Return comparable version for docker CLI tags such as 29-cli or 29.6.0-cli."""
+    match = re.fullmatch(r"(\d+)(?:\.(\d+))?(?:\.(\d+))?-cli", tag)
+    if not match:
+        return None
+    return tuple(int(part or 0) for part in match.groups())
+
+
 def latest_docker_cli_tag(current_tag: str) -> str | None:
     """
-    Given a tag like '27-cli' or '27.3-cli', find the latest same-or-newer
-    major-version 'XX-cli' tag on Docker Hub.
+    Given a tag like '29-cli', '29.6-cli' or '29.6.0-cli', find the latest
+    same-or-newer docker CLI tag on Docker Hub.
     Returns the tag name if a newer one is found, else None.
     """
-    m = re.match(r"^(\d+)", current_tag)
-    if not m:
+    current_version = _docker_cli_version(current_tag)
+    if not current_version:
         return None
-    current_major = int(m.group(1))
+    current_major = current_version[0]
+
+    candidates: list[tuple[tuple[int, int, int], str]] = []
 
     # Try current+1 first (prefer upgrade), then current (patch within major)
     for try_major in (current_major + 1, current_major):
         for tag in _hub_tags("docker", str(try_major)):
-            # Accept only exact "XX-cli" pattern (not "XX.Y.Z-cli" floaters)
-            if tag == f"{try_major}-cli":
-                return tag
-    return None
+            version = _docker_cli_version(tag)
+            if version and version[0] >= current_major and version > current_version:
+                candidates.append((version, tag))
+    if not candidates:
+        return None
+    return max(candidates)[1]
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +181,7 @@ def main() -> None:
                         )
                 else:
                     pr_lines.append(
-                        f"> ⚠️ No newer `docker:XX-cli` tag found on Docker Hub "
+                        f"> ⚠️ No newer `docker:*cli` tag found on Docker Hub "
                         f"(current: `docker:{current_tag}`). Manual review required.\n\n"
                     )
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1 — récupère uniquement le binaire docker CLI (pas le daemon)
-# docker:28-cli — Go stdlib patché (CVE-2025-68121, CVE-2024-45337, CVE-2026-33186)
-#                  + docker/docker v27.1.1+ (CVE-2024-41110)
-FROM docker:29-cli AS docker-bin
+# docker:29.6.0-cli — tag précis pour récupérer les correctifs Go/containerd
+#                    sans attendre que le tag flottant docker:29-cli soit rescanné.
+FROM docker:29.6.0-cli AS docker-bin
 
 # Stage 2 — image finale
 FROM python:3.12-slim

--- a/tests/test_trivy_autofix.py
+++ b/tests/test_trivy_autofix.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / '.github' / 'scripts' / 'trivy_autofix.py'
+SPEC = importlib.util.spec_from_file_location('trivy_autofix', SCRIPT_PATH)
+trivy_autofix = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(trivy_autofix)
+
+
+class TrivyAutofixTest(TestCase):
+    def test_latest_docker_cli_tag_accepts_precise_patch_tags(self) -> None:
+        with patch.object(
+            trivy_autofix,
+            '_hub_tags',
+            side_effect=lambda image, major: {
+                '30': [],
+                '29': ['29-cli', '29.6-cli', '29.6.0-cli', '29.6.0-dind', '29.5.2-cli'],
+            }.get(major, []),
+        ):
+            self.assertEqual(
+                trivy_autofix.latest_docker_cli_tag('29-cli'),
+                '29.6.0-cli',
+            )
+
+    def test_latest_docker_cli_tag_returns_none_when_current_is_latest(self) -> None:
+        with patch.object(
+            trivy_autofix,
+            '_hub_tags',
+            side_effect=lambda image, major: {
+                '30': [],
+                '29': ['29-cli', '29.6-cli', '29.6.0-cli'],
+            }.get(major, []),
+        ):
+            self.assertIsNone(trivy_autofix.latest_docker_cli_tag('29.6.0-cli'))


### PR DESCRIPTION
## Résumé

- met à jour l’image Docker CLI de `docker:29-cli` vers `docker:29.6.0-cli` pour récupérer les correctifs récents ;
- corrige le script d’autofix Trivy afin qu’il détecte aussi les tags précis `29.x.y-cli`, et plus seulement `29-cli` ;
- ajoute des tests unitaires pour éviter que le workflow rate à nouveau les tags Docker CLI patchés.

## Issue liée

Répond à #16.

## Validation

- 17 tests unitaires réussis ;
- compilation Python réussie ;
- contrôle UTF-8 réussi ;
- `git diff --check` réussi.
