### PR TITLE
Add Unraid DockerMan control backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 claude_*.txt
 rapport_*.txt
 CHANTIER.md
+plan.md
+CLAUDE.md
+AGENTS.md
 
 # ── Python ──────────────────────────────────────────────────────────────────
 __pycache__/

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -144,6 +144,51 @@ def _detect_compose_service(container_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Control-backend detection
+# ---------------------------------------------------------------------------
+# Companion drives Gluetun differently depending on how the container is
+# managed.  Compose stacks are recreated with ``docker compose up -d``.  Unraid's
+# Docker Manager (``net.unraid.docker.managed=dockerman``) has no compose
+# project, so the container is recreated from its Unraid template instead.
+# Detection is automatic per container; the ``CONTROL_BACKEND`` environment
+# variable (``auto`` | ``compose`` | ``unraid``) forces a backend when needed.
+
+CONTROL_BACKEND_COMPOSE = 'compose'
+CONTROL_BACKEND_UNRAID = 'unraid'
+
+
+def _control_backend_override() -> str:
+    """Return a forced control backend from the environment, or '' for auto."""
+    value = (os.environ.get('CONTROL_BACKEND', '') or '').strip().lower()
+    return value if value in (CONTROL_BACKEND_COMPOSE, CONTROL_BACKEND_UNRAID) else ''
+
+
+def _management_mode(container_name: str) -> str:
+    """Return the control backend for *container_name*: 'compose' or 'unraid'.
+
+    Resolution order (first match wins):
+      1. ``CONTROL_BACKEND`` override (``compose``/``unraid``), when set;
+      2. a ``com.docker.compose.project`` label        → ``compose``;
+      3. ``net.unraid.docker.managed=dockerman`` label → ``unraid``;
+      4. default                                        → ``compose``
+         (preserves the historical behaviour for plain ``docker run`` setups).
+    """
+    override = _control_backend_override()
+    if override:
+        return override
+    try:
+        labels = docker.from_env().containers.get(container_name).labels or {}
+    except Exception as exc:
+        logger.warning('_management_mode(%s): %s — defaulting to compose', container_name, exc)
+        return CONTROL_BACKEND_COMPOSE
+    if labels.get('com.docker.compose.project'):
+        return CONTROL_BACKEND_COMPOSE
+    if (labels.get('net.unraid.docker.managed') or '').strip().lower() == 'dockerman':
+        return CONTROL_BACKEND_UNRAID
+    return CONTROL_BACKEND_COMPOSE
+
+
+# ---------------------------------------------------------------------------
 # Docker / container helpers
 # ---------------------------------------------------------------------------
 
@@ -172,6 +217,96 @@ def format_filters(filters: dict[str, str]) -> str:
     for value in filters.values():
         labels.extend(part.strip() for part in str(value).split(',') if part.strip())
     return ' · '.join(labels) if labels else '—'
+
+
+def _managed_env_pairs(
+    filter_value: str,
+    filter_type: str,
+    wg_profile: 'dict | None',
+) -> list[tuple[str, str]]:
+    """Compute the ordered (key, value) env vars Companion manages for a switch.
+
+    Single source of truth shared by every control backend (Compose override,
+    Unraid template recreate) so they all write exactly the same values and can
+    never diverge.  Values are RAW — each backend escapes them for its own
+    target format (YAML double-quoted, XML text, …).
+
+    Order (kept stable so the Compose override output is unchanged):
+      1. every SERVER_* filter var — the target one set to *filter_value*,
+         all others blanked so base-compose values cannot conflict;
+      2. DNS filtering (BLOCK_MALICIOUS, DNS_UNBLOCK_HOSTNAMES);
+      3. when *wg_profile* is given: VPN_SERVICE_PROVIDER, VPN_TYPE, the profile
+         credential vars, then every other known credential key blanked (so a
+         previous provider's secret cannot leak into the new session).
+    """
+    env_var = FILTER_VARS.get(filter_type, 'SERVER_NAMES')
+
+    compose_provider = ''
+    vpn_type = 'wireguard'
+    profile_vars: dict[str, str] = {}
+    if wg_profile:
+        compose_provider = wg_profile.get('compose_provider', '')
+        if wg_profile.get('vars') is not None:
+            profile_vars = dict(wg_profile.get('vars') or {})
+        else:
+            profile_vars = dict(wg_profile.get('extra_env') or {})
+        compose_provider = compose_provider or profile_vars.get('VPN_SERVICE_PROVIDER', '')
+        vpn_type = (
+            wg_profile.get('vpn_type')
+            or profile_vars.get('VPN_TYPE')
+            or 'wireguard'
+        )
+
+        # These values are generated explicitly below. Profiles imported from
+        # older code paths can still contain them, which would otherwise emit
+        # duplicate keys.
+        managed_vars = {
+            'VPN_SERVICE_PROVIDER',
+            'VPN_TYPE',
+            *FILTER_VARS.values(),
+        }
+        profile_vars = {
+            key: value for key, value in profile_vars.items()
+            if key not in managed_vars
+        }
+
+    uses_server_filter = compose_provider != 'custom'
+
+    pairs: list[tuple[str, str]] = []
+
+    # Set the target filter var, blank-out all others.
+    for label, var in FILTER_VARS.items():
+        raw = filter_value if uses_server_filter and var == env_var else ''
+        pairs.append((var, raw))
+
+    # DNS filtering is managed by Companion as well, so the user's choice
+    # survives every regenerated override and provider/server switch.
+    try:
+        dns_block_malicious = get_setting('dns_block_malicious', '1')
+        dns_unblock_hostnames = get_setting('dns_unblock_hostnames', '')
+    except Exception:
+        # Keep standalone uses and early-startup recovery aligned with
+        # Gluetun's own secure default if the settings DB is unavailable.
+        dns_block_malicious = '1'
+        dns_unblock_hostnames = ''
+    pairs.append(('BLOCK_MALICIOUS', 'on' if dns_block_malicious == '1' else 'off'))
+    pairs.append(('DNS_UNBLOCK_HOSTNAMES', dns_unblock_hostnames))
+
+    # VPN profile vars (provider + type + credentials).
+    if wg_profile:
+        if compose_provider:
+            pairs.append(('VPN_SERVICE_PROVIDER', compose_provider))
+        pairs.append(('VPN_TYPE', vpn_type))
+        for k, v in profile_vars.items():
+            pairs.append((k, v))
+        # Blank every known credential var the profile does not set, so values
+        # inherited from the base compose file (another provider/type) cannot
+        # leak into the new session (e.g. AirVPN preshared key on Mullvad).
+        from .wg_providers import all_credential_keys
+        for k in sorted(all_credential_keys() - set(profile_vars)):
+            pairs.append((k, ''))
+
+    return pairs
 
 
 def switch_server(
@@ -205,8 +340,6 @@ def switch_server(
 
     Returns (success, error_message).
     """
-    env_var = FILTER_VARS.get(filter_type, 'SERVER_NAMES')
-
     # Resolve project and service name BEFORE writing the override so that the
     # YAML key matches the actual Compose service name (which may differ from
     # the container_name when an explicit container_name: is set in the compose).
@@ -217,75 +350,12 @@ def switch_server(
         """Sanitise a value against YAML injection."""
         return raw.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '').replace('\r', '')
 
-    compose_provider = ''
-    vpn_type = 'wireguard'
-    profile_vars: dict[str, str] = {}
-    if wg_profile:
-        compose_provider = wg_profile.get('compose_provider', '')
-        if wg_profile.get('vars') is not None:
-            profile_vars = dict(wg_profile.get('vars') or {})
-        else:
-            profile_vars = dict(wg_profile.get('extra_env') or {})
-        compose_provider = compose_provider or profile_vars.get('VPN_SERVICE_PROVIDER', '')
-        vpn_type = (
-            wg_profile.get('vpn_type')
-            or profile_vars.get('VPN_TYPE')
-            or 'wireguard'
-        )
-
-        # These values are generated explicitly below. Profiles imported from
-        # older code paths can still contain them, which would otherwise emit
-        # duplicate YAML mapping keys and make Docker Compose reject the file.
-        managed_vars = {
-            'VPN_SERVICE_PROVIDER',
-            'VPN_TYPE',
-            *FILTER_VARS.values(),
-        }
-        profile_vars = {
-            key: value for key, value in profile_vars.items()
-            if key not in managed_vars
-        }
-
-    uses_server_filter = compose_provider != 'custom'
-
-    # Build environment block: set target filter var, blank-out all others
-    env_lines = ''
-    for label, var in FILTER_VARS.items():
-        raw = filter_value if uses_server_filter and var == env_var else ''
-        env_lines += f'      {var}: "{_safe(raw)}"\n'
-
-    # DNS filtering is managed by Companion as well, so the user's choice
-    # survives every regenerated override and provider/server switch.
-    try:
-        dns_block_malicious = get_setting('dns_block_malicious', '1')
-        dns_unblock_hostnames = get_setting('dns_unblock_hostnames', '')
-    except Exception:
-        # Keep standalone uses and early-startup recovery aligned with
-        # Gluetun's own secure default if the settings DB is unavailable.
-        dns_block_malicious = '1'
-        dns_unblock_hostnames = ''
-    env_lines += (
-        '      BLOCK_MALICIOUS: "'
-        + ('on' if dns_block_malicious == '1' else 'off')
-        + '"\n'
+    # Managed env vars (server filters + DNS + VPN profile) come from the single
+    # shared builder so every control backend writes exactly the same values.
+    env_lines = ''.join(
+        f'      {key}: "{_safe(value)}"\n'
+        for key, value in _managed_env_pairs(filter_value, filter_type, wg_profile)
     )
-    env_lines += (
-        f'      DNS_UNBLOCK_HOSTNAMES: "{_safe(dns_unblock_hostnames)}"\n'
-    )
-
-    # VPN profile vars (provider + type + credentials)
-    if wg_profile:
-        if compose_provider:
-            env_lines += f'      VPN_SERVICE_PROVIDER: "{_safe(compose_provider)}"\n'
-        env_lines += f'      VPN_TYPE: "{_safe(vpn_type)}"\n'
-        for k, v in profile_vars.items():
-            env_lines += f'      {k}: "{_safe(v)}"\n'
-        # Blank every known credential var the profile does not set, so values
-        # inherited from the base compose file (another provider/type) cannot
-        # leak into the new session (e.g. AirVPN preshared key on Mullvad).
-        from .wg_providers import all_credential_keys
-        for k in sorted(all_credential_keys() - set(profile_vars)):
-            env_lines += f'      {k}: ""\n'
 
     # Use the Compose service name (not the container name) as the YAML key so
     # that the override is applied to the correct service even when service name

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -989,7 +989,7 @@ def _known_gluetun_ids() -> set[str]:
 
 def list_network_dependents(container_name: str) -> list[str]:
     """
-    Return the sorted names of all containers that use
+    Return the sorted names of running containers that use
     ``network_mode: service:<container_name>`` (i.e. share Gluetun's namespace).
     Read-only — does not restart anything.
     """
@@ -1005,6 +1005,8 @@ def list_network_dependents(container_name: str) -> list[str]:
         name_target = f'container:{container_name}'
         id_target   = f'container:{gluetun_id}' if gluetun_id else None
         for c in client.containers.list(all=True):
+            if not (c.attrs.get('State') or {}).get('Running'):
+                continue
             mode = c.attrs['HostConfig'].get('NetworkMode', '')
             if mode == name_target or (id_target and mode == id_target):
                 result.append(c.name)
@@ -1018,9 +1020,9 @@ def list_network_dependents_for_recreate(container_name: str) -> list[str]:
     Extended version of ``list_network_dependents`` for use as a pre-switch
     capture.  Returns the union of:
 
-    * Containers that currently reference ``container_name`` by name or ID
+    * Running containers that currently reference ``container_name`` by name or ID
       (the normal case — Gluetun hasn't been recreated yet).
-    * Containers whose NetworkMode references a **dead** container ID
+    * Running containers whose NetworkMode references a **dead** container ID
       (orphaned from a previous Gluetun recreate that didn't fix dependents).
 
     The second set handles the scenario where a previous switch failed to
@@ -1080,6 +1082,8 @@ def list_orphaned_network_dependents() -> list[str]:
         legacy_pass = get_setting('orphan_legacy_adoption_done', '0') != '1'
 
         for c in all_containers:
+            if not (c.attrs.get('State') or {}).get('Running'):
+                continue
             mode = c.attrs['HostConfig'].get('NetworkMode', '')
             if not mode.startswith('container:'):
                 continue

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -309,6 +309,46 @@ def _managed_env_pairs(
     return pairs
 
 
+def _profile_secret_keys(wg_profile: 'dict | None') -> set[str]:
+    """Return the credential env keys that must be masked for *wg_profile*."""
+    if not wg_profile:
+        return set()
+    from .wg_providers import get_secret_field_keys
+    provider = (
+        wg_profile.get('compose_provider')
+        or (wg_profile.get('vars') or {}).get('VPN_SERVICE_PROVIDER', '')
+        or (wg_profile.get('extra_env') or {}).get('VPN_SERVICE_PROVIDER', '')
+    )
+    return get_secret_field_keys(provider, wg_profile.get('vpn_type', '') or '')
+
+
+def _unraid_apply_env_and_recreate(
+    container_name: str,
+    pairs: list[tuple[str, str]],
+    secret_keys: set[str],
+) -> None:
+    """Unraid control backend: persist managed env into the container's Unraid
+    template (so it survives Unraid auto-updates), then recreate the live
+    container from its inspect via the Docker SDK.
+    """
+    from . import unraid
+    template = unraid.find_template(container_name)
+    if template:
+        try:
+            unraid.write_template_env(template, pairs, secret_keys)
+        except Exception as exc:
+            logger.warning(
+                'Unraid template write-back failed for %s: %s — recreating live anyway',
+                container_name, exc,
+            )
+    else:
+        logger.warning(
+            'Unraid template for %s not found — recreating live only '
+            '(changes will not survive an Unraid container update)', container_name,
+        )
+    unraid.sdk_recreate(container_name, env_overrides=dict(pairs))
+
+
 def switch_server(
     filter_value: str,
     filter_type: str,
@@ -340,6 +380,20 @@ def switch_server(
 
     Returns (success, error_message).
     """
+    # Unraid (Docker Manager) hosts have no Compose project: persist the managed
+    # env into the container's template and recreate it via the Docker SDK.
+    if _management_mode(container_name) == CONTROL_BACKEND_UNRAID:
+        pairs = _managed_env_pairs(filter_value, filter_type, wg_profile)
+        mark_companion_restart()
+        try:
+            _unraid_apply_env_and_recreate(
+                container_name, pairs, _profile_secret_keys(wg_profile)
+            )
+            return True, None
+        except Exception as exc:
+            logger.error('Unraid server switch failed for %s: %s', container_name, exc)
+            return False, str(exc)
+
     # Resolve project and service name BEFORE writing the override so that the
     # YAML key matches the actual Compose service name (which may differ from
     # the container_name when an explicit container_name: is set in the compose).
@@ -414,6 +468,27 @@ def apply_dns_filtering(
     compose_project: str = '',
 ) -> tuple[bool, str | None]:
     """Persist DNS filtering values in Companion's override and recreate Gluetun."""
+    if _management_mode(container_name) == CONTROL_BACKEND_UNRAID:
+        pairs = [
+            ('BLOCK_MALICIOUS', 'on' if block_malicious else 'off'),
+            ('DNS_UNBLOCK_HOSTNAMES', unblock_hostnames),
+        ]
+        try:
+            deps = list_network_dependents_for_recreate(container_name)
+        except Exception:
+            deps = []
+        mark_companion_restart()
+        try:
+            _unraid_apply_env_and_recreate(container_name, pairs, set())
+        except Exception as exc:
+            logger.error('Unraid DNS update failed for %s: %s', container_name, exc)
+            return False, str(exc)
+        if deps:
+            restart_network_dependents(
+                container_name, compose_dir, compose_project, explicit_list=deps
+            )
+        return True, None
+
     service = _detect_compose_service(container_name)
     project = compose_project or _detect_compose_project(container_name)
     override_path = os.path.join(compose_dir, 'docker-compose.override.yml')
@@ -693,7 +768,11 @@ def restart_network_dependents(
                 logger.info('  pull %s: %s%s', img, 'updated' if updated else 'up to date', '' if ok else ' (failed)')
                 if updated:
                     updated_imgs.append(img)
-            _compose_recreate(name, compose_dir, compose_project)
+            if _management_mode(name) == CONTROL_BACKEND_UNRAID:
+                from . import unraid
+                unraid.sdk_recreate(name, network_mode=f'container:{container_name}')
+            else:
+                _compose_recreate(name, compose_dir, compose_project)
             restarted.append(name)
         except Exception as exc:
             logger.warning('Failed to recreate %s: %s', name, exc)
@@ -741,6 +820,7 @@ def start_stopped_containers(
     compose_dir: str = '',
     compose_project: str = '',
     pull_set: set[str] | None = None,
+    gluetun_name: str = '',
 ) -> list[str]:
     """
     Start containers that were previously stopped (but not removed) via
@@ -797,7 +877,14 @@ def start_stopped_containers(
                         # the container's own label (avoids using host-side paths
                         # from com.docker.compose.project.working_dir that are
                         # inaccessible from inside the Companion container).
-                        if compose_dir and (not compose_project or container_project == compose_project):
+                        if gluetun_name and _management_mode(name) == CONTROL_BACKEND_UNRAID:
+                            from . import unraid
+                            logger.info(
+                                '%s is Unraid-managed — recreating to rejoin %s namespace',
+                                name, gluetun_name,
+                            )
+                            unraid.sdk_recreate(name, network_mode=f'container:{gluetun_name}')
+                        elif compose_dir and (not compose_project or container_project == compose_project):
                             effective_project = compose_project or container_project
                             logger.info(
                                 '%s — compose recreate with dir=%r project=%r',

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -2066,7 +2066,8 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
             # so they don't need compose recreate.  This also works for
             # containers from stacks other than the gluetun stack.
             _resumed = start_stopped_containers(pause_containers, compose_dir, project,
-                                                pull_set=pull_pause_bench_set)
+                                                pull_set=pull_pause_bench_set,
+                                                gluetun_name=container)
             logger.info(
                 'Paused containers restarted: %d/%d',
                 len(_resumed), len(pause_containers),

--- a/app/unraid.py
+++ b/app/unraid.py
@@ -1,0 +1,312 @@
+"""
+Unraid control backend for Gluetun Companion.
+
+On Unraid, containers are created by the Docker Manager (label
+``net.unraid.docker.managed=dockerman``) from a per-container template XML in
+``/boot/config/plugins/dockerMan/templates-user/`` — there is no Docker Compose
+project, so Companion cannot drive them with ``docker compose up -d``.
+
+This module provides the Unraid-specific half of the control layer:
+
+- locate a container's Unraid template;
+- write Companion-managed environment variables back into that template
+  (``<Config Type="Variable">`` nodes), so the change **persists** and survives
+  Unraid's own recreate-from-template on auto-update;
+- (recreate of the live container is handled separately via the Docker SDK).
+
+The whole module is gated behind ``gluetun._management_mode() == 'unraid'`` so a
+plain Docker / Compose host never touches any of this.
+
+Design notes
+------------
+- Template write-back is done with **surgical regex text edits**, not a full XML
+  re-serialisation: Unraid templates contain HTML entities (``&#x1F389;``,
+  ``&amp;gt;`` …) and hand-formatted text that ``xml.etree`` would mangle on
+  rewrite.  We only replace the value of the targeted ``<Config>`` nodes and
+  leave every other byte untouched.
+- A timestamped ``.bak`` copy is written before any modification.
+- Secret values are never logged — only the variable names that changed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import time
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TEMPLATE_DIR = '/boot/config/plugins/dockerMan/templates-user'
+
+
+def template_dir() -> str:
+    """Directory holding the Unraid user templates (env-overridable)."""
+    return (os.environ.get('UNRAID_TEMPLATE_DIR', '') or DEFAULT_TEMPLATE_DIR).strip()
+
+
+# ---------------------------------------------------------------------------
+# Template lookup
+# ---------------------------------------------------------------------------
+
+_NAME_RE = re.compile(r'<Name>\s*([^<\s][^<]*?)\s*</Name>')
+
+
+def _template_name(text: str) -> str:
+    m = _NAME_RE.search(text)
+    return m.group(1).strip() if m else ''
+
+
+def find_template(container_name: str, directory: str | None = None) -> str | None:
+    """Return the path of the Unraid template whose ``<Name>`` matches.
+
+    Matching is by the template's ``<Name>`` element (authoritative), not the
+    filename, so a container renamed in the UI is still found.  Returns ``None``
+    when no template directory or no match is found.
+    """
+    directory = directory or template_dir()
+    if not container_name or not os.path.isdir(directory):
+        return None
+    try:
+        candidates = sorted(
+            os.path.join(directory, f)
+            for f in os.listdir(directory)
+            if f.lower().endswith('.xml')
+        )
+    except OSError as exc:
+        logger.warning('find_template: cannot list %s: %s', directory, exc)
+        return None
+    for path in candidates:
+        try:
+            with open(path, encoding='utf-8') as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        if _template_name(text) == container_name:
+            return path
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Template env write-back
+# ---------------------------------------------------------------------------
+
+def _xml_escape(value: str) -> str:
+    return (
+        value.replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
+        .replace('"', '&quot;')
+    )
+
+
+def _attr(tag: str, name: str) -> str:
+    m = re.search(r'\b' + re.escape(name) + r'="([^"]*)"', tag)
+    return m.group(1) if m else ''
+
+
+# Matches a whole <Config …>…</Config> or self-closing <Config …/> element.
+_CONFIG_RE = re.compile(
+    r'<Config\b(?P<tag>[^>]*?)(?:/>|>(?P<val>.*?)</Config>)',
+    re.DOTALL,
+)
+
+
+def update_template_env(
+    template_text: str,
+    pairs: list[tuple[str, str]],
+    secret_keys: 'frozenset[str] | set[str]' = frozenset(),
+) -> tuple[str, list[str]]:
+    """Return ``(new_text, changed_keys)`` with managed env vars written in.
+
+    For every ``(name, value)`` in *pairs*, the ``<Config Type="Variable"
+    Target="name">`` node's value is replaced (existing node) or a new node is
+    inserted before ``</Container>`` (missing).  Only ``Type="Variable"`` nodes
+    are touched — ``Port``/``Path`` nodes that happen to share a target are left
+    alone.  Everything else in the file is preserved byte-for-byte.
+    """
+    wanted = dict(pairs)
+    seen: set[str] = set()
+
+    def _repl(m: re.Match) -> str:
+        tag = m.group('tag')
+        if _attr(tag, 'Type') != 'Variable':
+            return m.group(0)
+        target = _attr(tag, 'Target')
+        if target not in wanted:
+            return m.group(0)
+        seen.add(target)
+        return f'<Config{tag}>{_xml_escape(wanted[target])}</Config>'
+
+    new_text = _CONFIG_RE.sub(_repl, template_text)
+
+    missing = [(n, v) for n, v in pairs if n not in seen]
+    if missing:
+        block = ''.join(
+            f'  <Config Name="{n}" Target="{n}" Default="" Mode="" Description="" '
+            f'Type="Variable" Display="always" Required="false" '
+            f'Mask="{"true" if n in secret_keys else "false"}">{_xml_escape(v)}</Config>\n'
+            for n, v in missing
+        )
+        new_text, count = re.subn(
+            r'</Container>', lambda _m: block + '</Container>', new_text, count=1
+        )
+        if count == 0:
+            logger.warning('update_template_env: no </Container> found, appending block')
+            new_text = new_text + '\n' + block
+
+    changed = [n for n, _ in pairs]
+    return new_text, changed
+
+
+def write_template_env(
+    template_path: str,
+    pairs: list[tuple[str, str]],
+    secret_keys: 'frozenset[str] | set[str]' = frozenset(),
+) -> list[str]:
+    """Back up *template_path* then write the managed env vars into it.
+
+    Returns the list of variable names written.  Never logs secret values.
+    """
+    with open(template_path, encoding='utf-8') as fh:
+        original = fh.read()
+    new_text, changed = update_template_env(original, pairs, secret_keys)
+    if new_text == original:
+        logger.info('Unraid template %s already up to date', template_path)
+        return []
+
+    backup = f'{template_path}.bak-{time.strftime("%Y%m%d-%H%M%S")}'
+    shutil.copy2(template_path, backup)
+    tmp = template_path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8', newline='') as fh:
+        fh.write(new_text)
+    os.replace(tmp, template_path)
+
+    loggable = [n for n in changed if n not in secret_keys]
+    redacted = [n for n in changed if n in secret_keys]
+    logger.info(
+        'Unraid template updated: %s (backup %s); set %s%s',
+        template_path, backup, loggable,
+        f' + {len(redacted)} secret var(s)' if redacted else '',
+    )
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# Container recreate (Docker SDK) — replay a container faithfully, changing only
+# the environment (and, for dependents, the network namespace reference).
+# ---------------------------------------------------------------------------
+
+def _strip_image_env(
+    container_env: 'list[str] | None',
+    image_env: 'list[str] | None',
+) -> list[str]:
+    """Drop env entries identical to the image's baked defaults.
+
+    Docker layers image env first, then explicit ``-e`` values.  Replaying only
+    the entries that differ from the image keeps the effective environment
+    identical while letting image-baked vars (``PATH``, s6/linuxserver
+    internals, gluetun option defaults …) float with image updates instead of
+    being pinned to the values captured at inspect time.  ``image_env=None``
+    strips nothing (back-compatible).
+    """
+    if not image_env:
+        return list(container_env or [])
+    baked = set(image_env)
+    return [e for e in (container_env or []) if e not in baked]
+
+
+def _merge_env(current: 'list[str] | None', overrides: dict[str, str]) -> list[str]:
+    """Merge a container's ``Config.Env`` list with override key/values.
+
+    Existing keys are replaced in place (order preserved); new keys are appended.
+    Blank overrides are kept (mirrors Companion's credential-blanking).
+    """
+    out: list[str] = []
+    remaining = dict(overrides)
+    for item in current or []:
+        key = item.split('=', 1)[0]
+        if key in remaining:
+            out.append(f'{key}={remaining.pop(key)}')
+        else:
+            out.append(item)
+    for key, value in remaining.items():
+        out.append(f'{key}={value}')
+    return out
+
+
+def _ports_from_bindings(port_bindings: 'dict | None') -> dict:
+    """Convert inspect ``HostConfig.PortBindings`` to the docker-py ``ports`` kwarg."""
+    ports: dict = {}
+    for cport, binds in (port_bindings or {}).items():
+        hosts = []
+        for b in binds or []:
+            ip = (b or {}).get('HostIp') or ''
+            hp = (b or {}).get('HostPort') or ''
+            if not hp:
+                continue
+            hosts.append((ip, int(hp)) if ip else int(hp))
+        if len(hosts) == 1:
+            ports[cport] = hosts[0]
+        elif hosts:
+            ports[cport] = hosts
+    return ports
+
+
+def _devices_from_inspect(devices: 'list | None') -> list[str]:
+    out: list[str] = []
+    for d in devices or []:
+        host = (d or {}).get('PathOnHost', '')
+        cont = (d or {}).get('PathInContainer', '') or host
+        perms = (d or {}).get('CgroupPermissions', 'rwm') or 'rwm'
+        if host:
+            out.append(f'{host}:{cont}:{perms}')
+    return out
+
+
+def recreate_kwargs_from_inspect(
+    attrs: dict,
+    env_overrides: 'dict[str, str] | None' = None,
+    network_mode: 'str | None' = None,
+    image_env: 'list[str] | None' = None,
+) -> dict:
+    """Build ``client.containers.run`` kwargs that re-create *attrs* faithfully.
+
+    Only the environment (merged with *env_overrides*) and, optionally, the
+    network mode are changed.  Everything else — image, labels (incl.
+    ``net.unraid.docker.managed``), caps, sysctls, devices, volumes, published
+    ports, restart policy — is replayed from the live ``docker inspect`` so the
+    container stays byte-for-byte the one Unraid created.
+
+    *image_env* (the image's ``Config.Env``) is stripped from the replayed
+    environment so image-baked defaults are not pinned — see ``_strip_image_env``.
+    """
+    config = attrs.get('Config', {}) or {}
+    host = attrs.get('HostConfig', {}) or {}
+    name = (attrs.get('Name', '') or '').lstrip('/')
+    rp = host.get('RestartPolicy') or {}
+
+    kwargs: dict = {
+        'name': name,
+        'image': config.get('Image', ''),
+        'environment': _merge_env(
+            _strip_image_env(config.get('Env'), image_env), env_overrides or {}
+        ),
+        'labels': config.get('Labels') or {},
+        'network_mode': network_mode or host.get('NetworkMode', '') or 'bridge',
+        'cap_add': list(host.get('CapAdd') or []),
+        'cap_drop': list(host.get('CapDrop') or []),
+        'sysctls': dict(host.get('Sysctls') or {}),
+        'devices': _devices_from_inspect(host.get('Devices')),
+        'volumes': list(host.get('Binds') or []),
+        'restart_policy': rp if rp.get('Name') else None,
+        'privileged': bool(host.get('Privileged')),
+        'dns': list(host.get('Dns') or []),
+        'detach': True,
+    }
+    # Published ports are meaningless (and rejected by Docker) for a container
+    # that shares another container's network namespace.
+    if not str(kwargs['network_mode']).startswith('container:'):
+        kwargs['ports'] = _ports_from_bindings(host.get('PortBindings'))
+    return kwargs

--- a/app/unraid.py
+++ b/app/unraid.py
@@ -300,7 +300,7 @@ def recreate_kwargs_from_inspect(
         'sysctls': dict(host.get('Sysctls') or {}),
         'devices': _devices_from_inspect(host.get('Devices')),
         'volumes': list(host.get('Binds') or []),
-        'restart_policy': rp if rp.get('Name') else None,
+        'restart_policy': rp if rp.get('Name') and rp.get('Name') != 'no' else None,
         'privileged': bool(host.get('Privileged')),
         'dns': list(host.get('Dns') or []),
         'detach': True,
@@ -310,3 +310,54 @@ def recreate_kwargs_from_inspect(
     if not str(kwargs['network_mode']).startswith('container:'):
         kwargs['ports'] = _ports_from_bindings(host.get('PortBindings'))
     return kwargs
+
+
+def sdk_recreate(
+    container_name: str,
+    env_overrides: 'dict[str, str] | None' = None,
+    network_mode: 'str | None' = None,
+    *,
+    stop_timeout: int = 30,
+):
+    """Recreate a container from its live inspect via the Docker SDK.
+
+    Stop and remove *container_name*, then re-create it with an identical
+    configuration except for the environment (merged with *env_overrides*, minus
+    image-baked defaults) and, optionally, *network_mode*.  On failure after
+    removal, attempt a best-effort rollback to the original configuration and
+    re-raise.  Returns the new container object.
+    """
+    import docker
+
+    client = docker.from_env()
+    c = client.containers.get(container_name)
+    attrs = c.attrs
+    try:
+        image_env = (
+            client.images.get(attrs.get('Config', {}).get('Image', ''))
+            .attrs.get('Config', {}).get('Env') or []
+        )
+    except Exception as exc:
+        logger.warning('sdk_recreate: cannot read image env for %s: %s', container_name, exc)
+        image_env = []
+
+    new_kwargs = recreate_kwargs_from_inspect(attrs, env_overrides, network_mode, image_env)
+    original_kwargs = recreate_kwargs_from_inspect(attrs, None, None, image_env)
+
+    logger.info('sdk_recreate: stopping + removing %s', container_name)
+    c.stop(timeout=stop_timeout)
+    c.remove()
+    try:
+        new = client.containers.run(**new_kwargs)
+        logger.info('sdk_recreate: %s recreated (id=%s)', container_name, new.short_id)
+        return new
+    except Exception as exc:
+        logger.error(
+            'sdk_recreate: recreate of %s failed (%s) — rolling back to original config',
+            container_name, exc,
+        )
+        try:
+            client.containers.run(**original_kwargs)
+        except Exception as rb:
+            logger.critical('sdk_recreate: ROLLBACK of %s FAILED: %s', container_name, rb)
+        raise

--- a/tests/fixtures/my-gluetun.xml
+++ b/tests/fixtures/my-gluetun.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>gluetun</Name>
+  <Repository>qmcgaw/gluetun:v3.39.1</Repository>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Overview>Gluetun &amp;gt; multi-provider VPN client &#x1F389; with NAT-PMP.</Overview>
+  <ExtraParams>--cap-add=NET_ADMIN --restart always --sysctl net.ipv6.conf.all.disable_ipv6=1</ExtraParams>
+  <Config Name="TIMEZONE" Target="TZ" Default="" Mode="" Description="tz" Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+  <Config Name="config" Target="/gluetun" Default="/mnt/user/appdata/gluetun" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/gluetun</Config>
+  <Config Name="VPN_SERVICE_PROVIDER" Target="VPN_SERVICE_PROVIDER" Default="" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false">protonvpn</Config>
+  <Config Name="VPN_TYPE" Target="VPN_TYPE" Default="" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false">wireguard</Config>
+  <Config Name="WIREGUARD_PRIVATE_KEY" Target="WIREGUARD_PRIVATE_KEY" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="true">PLACEHOLDER_SECRET_DO_NOT_USE=</Config>
+  <Config Name="UNBLOCK" Target="UNBLOCK" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="VPN_PORT_FORWARDING" Target="VPN_PORT_FORWARDING" Default="on" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">on</Config>
+  <Config Name="HTTP_CONTROL_SERVER_PORT" Target="8000" Default="8000" Mode="tcp" Description="" Type="Port" Display="advanced" Required="true" Mask="false">8222</Config>
+  <Config Name="SERVER_COUNTRIES" Target="SERVER_COUNTRIES" Default="" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">France</Config>
+</Container>

--- a/tests/test_gluetun_dependents.py
+++ b/tests/test_gluetun_dependents.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.gluetun import list_network_dependents, list_orphaned_network_dependents
+
+
+def _container(name, cid, network_mode='', running=True):
+    c = MagicMock()
+    c.name = name
+    c.id = cid
+    c.attrs = {
+        'HostConfig': {'NetworkMode': network_mode},
+        'State': {'Running': running},
+    }
+    return c
+
+
+class NetworkDependentsTest(unittest.TestCase):
+    @patch('app.gluetun.record_gluetun_id')
+    @patch('docker.from_env')
+    def test_network_dependents_ignore_stopped_containers(self, from_env, _record):
+        client = MagicMock()
+        gluetun = _container('gluetun', 'gluetun-full-id')
+        client.containers.get.return_value = gluetun
+        client.containers.list.return_value = [
+            _container('qbittorrent', 'qbit-id', 'container:gluetun', running=True),
+            _container('prowlarr', 'prowlarr-id', 'container:gluetun-full-id', running=True),
+            _container('helper', 'helper-id', 'container:gluetun', running=False),
+        ]
+        from_env.return_value = client
+
+        deps = list_network_dependents('gluetun')
+
+        self.assertEqual(deps, ['prowlarr', 'qbittorrent'])
+
+    @patch('app.gluetun._known_gluetun_ids', return_value={'dead-gluetun-id'})
+    @patch('app.database.get_setting', return_value='1')
+    @patch('docker.from_env')
+    def test_orphaned_dependents_ignore_stopped_containers(self, from_env, _get_setting, _known_ids):
+        client = MagicMock()
+        client.containers.list.return_value = [
+            _container('gluetun', 'current-gluetun-id', 'bridge', running=True),
+            _container('qbittorrent', 'qbit-id', 'container:dead-gluetun-id', running=True),
+            _container('helper', 'helper-id', 'container:dead-gluetun-id', running=False),
+        ]
+        from_env.return_value = client
+
+        deps = list_orphaned_network_dependents()
+
+        self.assertEqual(deps, ['qbittorrent'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_management_mode.py
+++ b/tests/test_management_mode.py
@@ -1,0 +1,95 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.gluetun import (
+    CONTROL_BACKEND_COMPOSE,
+    CONTROL_BACKEND_UNRAID,
+    _managed_env_pairs,
+    _management_mode,
+)
+
+
+def _dns_setting(key, default=''):
+    return {'dns_block_malicious': '1', 'dns_unblock_hostnames': ''}.get(key, default)
+
+
+class ManagedEnvPairsTest(unittest.TestCase):
+    """The shared env builder is the single source of truth for every backend."""
+
+    @patch('app.gluetun.get_setting', side_effect=_dns_setting)
+    def test_filter_targets_one_var_and_blanks_others(self, _gs):
+        d = dict(_managed_env_pairs('France', 'country', None))
+        self.assertEqual(d['SERVER_COUNTRIES'], 'France')
+        self.assertEqual(d['SERVER_NAMES'], '')
+        self.assertEqual(d['SERVER_CITIES'], '')
+        self.assertEqual(d['BLOCK_MALICIOUS'], 'on')
+
+    @patch('app.gluetun.get_setting', side_effect=_dns_setting)
+    def test_profile_sets_provider_type_and_blanks_other_credentials(self, _gs):
+        profile = {
+            'compose_provider': 'protonvpn',
+            'vpn_type': 'wireguard',
+            'vars': {'WIREGUARD_PRIVATE_KEY': 'secret-key'},
+        }
+        pairs = _managed_env_pairs('France', 'country', profile)
+        d = dict(pairs)
+        self.assertEqual(d['VPN_SERVICE_PROVIDER'], 'protonvpn')
+        self.assertEqual(d['VPN_TYPE'], 'wireguard')
+        self.assertEqual(d['WIREGUARD_PRIVATE_KEY'], 'secret-key')
+        # A different provider's credential is blanked out (anti-leak).
+        self.assertEqual(d['WIREGUARD_PRESHARED_KEY'], '')
+        keys = [k for k, _ in pairs]
+        self.assertEqual(keys.count('VPN_SERVICE_PROVIDER'), 1)
+        self.assertEqual(keys.count('WIREGUARD_PRIVATE_KEY'), 1)
+
+    @patch('app.gluetun.get_setting', side_effect=_dns_setting)
+    def test_custom_provider_does_not_set_server_filter(self, _gs):
+        profile = {'compose_provider': 'custom', 'vpn_type': 'wireguard', 'vars': {}}
+        d = dict(_managed_env_pairs('France', 'country', profile))
+        self.assertEqual(d['SERVER_COUNTRIES'], '')
+
+
+class ManagementModeTest(unittest.TestCase):
+    def _mode_with_labels(self, labels):
+        client = MagicMock()
+        client.containers.get.return_value.labels = labels
+        with patch('app.gluetun.docker.from_env', return_value=client), \
+                patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('CONTROL_BACKEND', None)
+            return _management_mode('gluetun')
+
+    def test_compose_label_detected(self):
+        self.assertEqual(
+            self._mode_with_labels({'com.docker.compose.project': 'airvpn'}),
+            CONTROL_BACKEND_COMPOSE,
+        )
+
+    def test_unraid_label_detected(self):
+        self.assertEqual(
+            self._mode_with_labels({'net.unraid.docker.managed': 'dockerman'}),
+            CONTROL_BACKEND_UNRAID,
+        )
+
+    def test_default_is_compose(self):
+        self.assertEqual(self._mode_with_labels({}), CONTROL_BACKEND_COMPOSE)
+
+    def test_compose_wins_when_both_labels_present(self):
+        self.assertEqual(
+            self._mode_with_labels({
+                'com.docker.compose.project': 'x',
+                'net.unraid.docker.managed': 'dockerman',
+            }),
+            CONTROL_BACKEND_COMPOSE,
+        )
+
+    def test_env_override_forces_unraid_even_with_compose_label(self):
+        client = MagicMock()
+        client.containers.get.return_value.labels = {'com.docker.compose.project': 'x'}
+        with patch('app.gluetun.docker.from_env', return_value=client), \
+                patch.dict(os.environ, {'CONTROL_BACKEND': 'unraid'}):
+            self.assertEqual(_management_mode('gluetun'), CONTROL_BACKEND_UNRAID)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_management_mode.py
+++ b/tests/test_management_mode.py
@@ -7,6 +7,7 @@ from app.gluetun import (
     CONTROL_BACKEND_UNRAID,
     _managed_env_pairs,
     _management_mode,
+    switch_server,
 )
 
 
@@ -89,6 +90,36 @@ class ManagementModeTest(unittest.TestCase):
         with patch('app.gluetun.docker.from_env', return_value=client), \
                 patch.dict(os.environ, {'CONTROL_BACKEND': 'unraid'}):
             self.assertEqual(_management_mode('gluetun'), CONTROL_BACKEND_UNRAID)
+
+
+class SwitchServerUnraidDispatchTest(unittest.TestCase):
+    @patch('app.gluetun.get_setting', side_effect=_dns_setting)
+    @patch('app.gluetun._management_mode', return_value=CONTROL_BACKEND_UNRAID)
+    @patch('app.gluetun.mark_companion_restart')
+    @patch('app.gluetun._unraid_apply_env_and_recreate')
+    def test_unraid_mode_uses_unraid_backend(self, apply_recreate, _mark, _mode, _gs):
+        ok, err = switch_server(
+            'France', 'country', 'gluetun', '/compose',
+            wg_profile={'compose_provider': 'protonvpn', 'vpn_type': 'wireguard',
+                        'vars': {'WIREGUARD_PRIVATE_KEY': 'k'}},
+        )
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        apply_recreate.assert_called_once()
+        container, pairs, _secret = apply_recreate.call_args.args
+        self.assertEqual(container, 'gluetun')
+        d = dict(pairs)
+        self.assertEqual(d['VPN_SERVICE_PROVIDER'], 'protonvpn')
+        self.assertEqual(d['SERVER_COUNTRIES'], 'France')
+
+    @patch('app.gluetun.get_setting', side_effect=_dns_setting)
+    @patch('app.gluetun._management_mode', return_value=CONTROL_BACKEND_UNRAID)
+    @patch('app.gluetun.mark_companion_restart')
+    @patch('app.gluetun._unraid_apply_env_and_recreate', side_effect=RuntimeError('boom'))
+    def test_unraid_failure_returns_error(self, _apply, _mark, _mode, _gs):
+        ok, err = switch_server('France', 'country', 'gluetun', '/compose')
+        self.assertFalse(ok)
+        self.assertIn('boom', err)
 
 
 if __name__ == '__main__':

--- a/tests/test_unraid_recreate.py
+++ b/tests/test_unraid_recreate.py
@@ -1,0 +1,110 @@
+import unittest
+
+from app.unraid import recreate_kwargs_from_inspect
+
+
+def _gluetun_attrs():
+    """Representative `docker inspect` of the real Unraid Gluetun container."""
+    return {
+        'Name': '/gluetun',
+        'Config': {
+            'Image': 'qmcgaw/gluetun:v3.39.1',
+            'Env': [
+                'VPN_SERVICE_PROVIDER=protonvpn',
+                'VPN_TYPE=wireguard',
+                'WIREGUARD_PRIVATE_KEY=keep-this-secret=',
+                'VPN_PORT_FORWARDING=on',
+                'SERVER_COUNTRIES=France',
+            ],
+            'Labels': {
+                'net.unraid.docker.managed': 'dockerman',
+                'net.unraid.docker.webui': 'http://[IP]:[PORT:8222]',
+            },
+        },
+        'HostConfig': {
+            'NetworkMode': 'bridge',
+            'CapAdd': ['CAP_NET_ADMIN'],
+            'CapDrop': None,
+            'Sysctls': {'net.ipv6.conf.all.disable_ipv6': '1'},
+            'Devices': [],
+            'Binds': [
+                '/mnt/user/appdata/gluetun:/gluetun:rw',
+                '/mnt/user/appdata/gluetun/tmp:/tmp/gluetun:rw',
+            ],
+            'RestartPolicy': {'Name': 'always', 'MaximumRetryCount': 0},
+            'Privileged': False,
+            'Dns': [],
+            'PortBindings': {
+                '8000/tcp': [{'HostIp': '', 'HostPort': '8222'}],
+                '8080/tcp': [{'HostIp': '', 'HostPort': '8080'},
+                             {'HostIp': '', 'HostPort': '9892'}],
+            },
+        },
+    }
+
+
+class RecreateKwargsTest(unittest.TestCase):
+    def test_env_merge_replaces_and_appends_preserving_secret(self):
+        kw = recreate_kwargs_from_inspect(
+            _gluetun_attrs(),
+            env_overrides={'VPN_PORT_FORWARDING': 'on', 'PORT_FORWARD_ONLY': 'on',
+                           'SERVER_COUNTRIES': 'Germany'},
+        )
+        env = kw['environment']
+        self.assertIn('WIREGUARD_PRIVATE_KEY=keep-this-secret=', env)  # secret kept
+        self.assertIn('SERVER_COUNTRIES=Germany', env)                 # replaced in place
+        self.assertIn('PORT_FORWARD_ONLY=on', env)                     # appended
+        self.assertEqual(env.count('VPN_PORT_FORWARDING=on'), 1)       # not duplicated
+        # order preserved: replaced key stays at its original index
+        self.assertEqual([e.split('=', 1)[0] for e in env][:5],
+                         ['VPN_SERVICE_PROVIDER', 'VPN_TYPE', 'WIREGUARD_PRIVATE_KEY',
+                          'VPN_PORT_FORWARDING', 'SERVER_COUNTRIES'])
+
+    def test_labels_caps_sysctls_preserved(self):
+        kw = recreate_kwargs_from_inspect(_gluetun_attrs())
+        self.assertEqual(kw['labels']['net.unraid.docker.managed'], 'dockerman')
+        self.assertEqual(kw['cap_add'], ['CAP_NET_ADMIN'])
+        self.assertEqual(kw['sysctls'], {'net.ipv6.conf.all.disable_ipv6': '1'})
+        self.assertEqual(kw['restart_policy'], {'Name': 'always', 'MaximumRetryCount': 0})
+        self.assertIn('/mnt/user/appdata/gluetun:/gluetun:rw', kw['volumes'])
+
+    def test_ports_single_and_multiple(self):
+        kw = recreate_kwargs_from_inspect(_gluetun_attrs())
+        self.assertEqual(kw['ports']['8000/tcp'], 8222)
+        self.assertEqual(sorted(kw['ports']['8080/tcp']), [8080, 9892])
+
+    def test_dependent_uses_network_name_and_drops_ports(self):
+        attrs = {
+            'Name': '/qbittorrent',
+            'Config': {'Image': 'lscr.io/linuxserver/qbittorrent',
+                       'Env': ['PUID=1000'], 'Labels': {'net.unraid.docker.managed': 'dockerman'}},
+            'HostConfig': {
+                'NetworkMode': 'container:OLD_GLUETUN_ID',
+                'Binds': ['/mnt/user/appdata/qbittorrent:/config:rw'],
+                'RestartPolicy': {'Name': 'unless-stopped', 'MaximumRetryCount': 0},
+                'PortBindings': {},
+            },
+        }
+        kw = recreate_kwargs_from_inspect(attrs, network_mode='container:gluetun')
+        self.assertEqual(kw['network_mode'], 'container:gluetun')
+        self.assertNotIn('ports', kw)  # ports invalid when sharing a namespace
+
+    def test_image_baked_env_is_stripped(self):
+        attrs = _gluetun_attrs()
+        attrs['Config']['Env'].append('PATH=/usr/local/sbin:/usr/bin')
+        image_env = ['PATH=/usr/local/sbin:/usr/bin', 'S6_VERBOSITY=1']
+        kw = recreate_kwargs_from_inspect(attrs, image_env=image_env)
+        self.assertNotIn('PATH=/usr/local/sbin:/usr/bin', kw['environment'])
+        # explicitly-set vars are kept
+        self.assertIn('VPN_SERVICE_PROVIDER=protonvpn', kw['environment'])
+        self.assertIn('SERVER_COUNTRIES=France', kw['environment'])
+
+    def test_empty_restart_policy_becomes_none(self):
+        attrs = _gluetun_attrs()
+        attrs['HostConfig']['RestartPolicy'] = {'Name': '', 'MaximumRetryCount': 0}
+        kw = recreate_kwargs_from_inspect(attrs)
+        self.assertIsNone(kw['restart_policy'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_unraid_recreate.py
+++ b/tests/test_unraid_recreate.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
-from app.unraid import recreate_kwargs_from_inspect
+from app.unraid import recreate_kwargs_from_inspect, sdk_recreate
 
 
 def _gluetun_attrs():
@@ -104,6 +105,41 @@ class RecreateKwargsTest(unittest.TestCase):
         attrs['HostConfig']['RestartPolicy'] = {'Name': '', 'MaximumRetryCount': 0}
         kw = recreate_kwargs_from_inspect(attrs)
         self.assertIsNone(kw['restart_policy'])
+
+
+class SdkRecreateTest(unittest.TestCase):
+    @patch('docker.from_env')
+    def test_stops_removes_and_runs_with_merged_env(self, from_env):
+        client = MagicMock()
+        cont = MagicMock()
+        cont.attrs = _gluetun_attrs()
+        client.containers.get.return_value = cont
+        client.images.get.return_value.attrs = {'Config': {'Env': []}}
+        from_env.return_value = client
+
+        sdk_recreate('gluetun', env_overrides={'SERVER_COUNTRIES': 'Germany'})
+
+        cont.stop.assert_called_once()
+        cont.remove.assert_called_once()
+        client.containers.run.assert_called_once()
+        kw = client.containers.run.call_args.kwargs
+        self.assertEqual(kw['name'], 'gluetun')
+        self.assertIn('SERVER_COUNTRIES=Germany', kw['environment'])
+
+    @patch('docker.from_env')
+    def test_rolls_back_on_run_failure(self, from_env):
+        client = MagicMock()
+        cont = MagicMock()
+        cont.attrs = _gluetun_attrs()
+        client.containers.get.return_value = cont
+        client.images.get.return_value.attrs = {'Config': {'Env': []}}
+        client.containers.run.side_effect = [RuntimeError('boom'), MagicMock()]
+        from_env.return_value = client
+
+        with self.assertRaises(RuntimeError):
+            sdk_recreate('gluetun', env_overrides={'X': '1'})
+        # original run + rollback run
+        self.assertEqual(client.containers.run.call_count, 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_unraid_template.py
+++ b/tests/test_unraid_template.py
@@ -1,0 +1,100 @@
+import os
+import re
+import shutil
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from app.unraid import find_template, update_template_env, write_template_env
+
+FIXTURE = Path(__file__).parent / 'fixtures' / 'my-gluetun.xml'
+
+
+def _val(text, name):
+    m = re.search(r'<Config\b[^>]*\bTarget="' + name + r'"[^>]*>(.*?)</Config>', text)
+    return m.group(1) if m else None
+
+
+class FindTemplateTest(unittest.TestCase):
+    def test_finds_by_name_element(self):
+        with patch.dict(os.environ, {'UNRAID_TEMPLATE_DIR': str(FIXTURE.parent)}):
+            self.assertEqual(find_template('gluetun'), str(FIXTURE))
+
+    def test_returns_none_for_unknown(self):
+        with patch.dict(os.environ, {'UNRAID_TEMPLATE_DIR': str(FIXTURE.parent)}):
+            self.assertIsNone(find_template('does-not-exist'))
+
+    def test_returns_none_when_dir_missing(self):
+        with patch.dict(os.environ, {'UNRAID_TEMPLATE_DIR': '/no/such/dir'}):
+            self.assertIsNone(find_template('gluetun'))
+
+
+class UpdateTemplateEnvTest(unittest.TestCase):
+    def setUp(self):
+        self.text = FIXTURE.read_text(encoding='utf-8')
+
+    def test_updates_existing_variable(self):
+        new, changed = update_template_env(self.text, [('VPN_PORT_FORWARDING', 'off')])
+        self.assertEqual(_val(new, 'VPN_PORT_FORWARDING'), 'off')
+        self.assertIn('VPN_PORT_FORWARDING', changed)
+
+    def test_inserts_missing_variable_before_container_close(self):
+        new, _ = update_template_env(self.text, [('PORT_FORWARD_ONLY', 'on')])
+        self.assertEqual(_val(new, 'PORT_FORWARD_ONLY'), 'on')
+        self.assertIn('Target="PORT_FORWARD_ONLY"', new)
+        # inserted before the closing tag
+        self.assertLess(new.index('PORT_FORWARD_ONLY'), new.index('</Container>'))
+
+    def test_fills_self_closing_empty_variable(self):
+        new, _ = update_template_env(self.text, [('UNBLOCK', 'tracker.example.org')])
+        self.assertEqual(_val(new, 'UNBLOCK'), 'tracker.example.org')
+
+    def test_does_not_touch_port_node_value(self):
+        new, _ = update_template_env(self.text, [('SERVER_COUNTRIES', 'Germany')])
+        # the Control Server Port config (Target="8000") must stay intact
+        self.assertIn('Name="HTTP_CONTROL_SERVER_PORT"', new)
+        self.assertRegex(new, r'Name="HTTP_CONTROL_SERVER_PORT"[^>]*>8222</Config>')
+
+    def test_preserves_xml_entities_elsewhere(self):
+        new, _ = update_template_env(self.text, [('SERVER_COUNTRIES', 'Germany')])
+        self.assertIn('&#x1F389;', new)
+        self.assertIn('&amp;gt;', new)
+
+    def test_escapes_special_characters_in_value(self):
+        new, _ = update_template_env(self.text, [('SERVER_COUNTRIES', 'A&B<C>')])
+        self.assertEqual(_val(new, 'SERVER_COUNTRIES'), 'A&amp;B&lt;C&gt;')
+
+    def test_no_change_returns_identical_text(self):
+        new, _ = update_template_env(self.text, [('VPN_SERVICE_PROVIDER', 'protonvpn')])
+        self.assertEqual(new, self.text)
+
+
+class WriteTemplateEnvTest(unittest.TestCase):
+    def test_writes_backup_and_updates_file(self):
+        with TemporaryDirectory() as d:
+            path = os.path.join(d, 'my-gluetun.xml')
+            shutil.copy2(FIXTURE, path)
+            changed = write_template_env(
+                path,
+                [('VPN_PORT_FORWARDING', 'off'), ('WIREGUARD_PRIVATE_KEY', 'newsecret=')],
+                secret_keys={'WIREGUARD_PRIVATE_KEY'},
+            )
+            self.assertIn('VPN_PORT_FORWARDING', changed)
+            updated = Path(path).read_text(encoding='utf-8')
+            self.assertEqual(_val(updated, 'VPN_PORT_FORWARDING'), 'off')
+            self.assertEqual(_val(updated, 'WIREGUARD_PRIVATE_KEY'), 'newsecret=')
+            backups = [f for f in os.listdir(d) if '.bak-' in f]
+            self.assertEqual(len(backups), 1)
+
+    def test_noop_when_already_current_writes_no_backup(self):
+        with TemporaryDirectory() as d:
+            path = os.path.join(d, 'my-gluetun.xml')
+            shutil.copy2(FIXTURE, path)
+            changed = write_template_env(path, [('VPN_SERVICE_PROVIDER', 'protonvpn')])
+            self.assertEqual(changed, [])
+            self.assertEqual([f for f in os.listdir(d) if '.bak-' in f], [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an auto-detected Unraid/DockerMan management backend alongside the existing Compose flow.

- Detects DockerMan-managed Gluetun containers and writes server/env changes back to the Unraid XML template.
- Recreates Gluetun through Docker SDK when running in Unraid mode, preserving ports, binds, env, extra hosts, labels, restart policy and network settings.
- Routes Gluetun switch/DNS/dependent recreation through the selected backend.
- Keeps intentionally stopped Gluetun network dependents stopped; only running dependents are recreated.

## Why

Unraid users install Gluetun through DockerMan rather than a Compose stack, so Companion needs a backend that can persist changes in DockerMan XML and recreate containers safely without relying on `docker compose`.

## Validation

- `python -m unittest tests.test_management_mode tests.test_unraid_recreate tests.test_unraid_template tests.test_gluetun_dependents`
- Result: 32 tests OK

This is part 1 of a small stacked series. Proton-specific changes and the Unraid template are intentionally left for follow-up PRs.