### PR TITLE
Add Unraid DockerMan template

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,10 +6,10 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: aerya
 
 jobs:
   companion:
@@ -21,6 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image namespace
+        run: echo "IMAGE_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -67,6 +70,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image namespace
+        run: echo "IMAGE_NAMESPACE=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'

--- a/README.en.md
+++ b/README.en.md
@@ -221,6 +221,8 @@ docker compose up -d
 
 Open **http://localhost:8765** — first login: enter the credentials you want (account created automatically).
 
+> **Unraid / DockerMan:** a temporary XML template is available in [`templates/unraid`](templates/unraid/README.md) for manual install or *Private Apps*, pending a possible Community Applications publication.
+
 > **Companion in the same stack as Gluetun?**
 > Remove `extra_hosts` and use the service name: `GLUETUN_HOST: gluetun`.
 > On a switch, the companion only targets the Gluetun service (`docker compose up -d <service>`) — it never restarts itself.
@@ -348,7 +350,7 @@ The **VPN Status** card displays the intermediary and observed operators. In tab
 **Prerequisites** — the catalogue sidecar only needs outbound HTTPS access (Docker bridge network, enabled by default). **No `docker-compose.yml` changes required.**
 
 ### Docker container management
-- **Gluetun network containers (auto-managed)** — all containers using `network_mode: service:gluetun` are detected and recreated automatically after each switch, regardless of their state: containers still functional **or already stuck in a dead namespace** (left over from a previously failed switch). Containers in a **different Compose stack** from Gluetun are also handled if their directory is accessible from Companion or if their `com.docker.compose` labels are present. Orphan detection is limited to containers referencing a **known former Gluetun** (ID history kept in the database) — Companion never touches dependents of another VPN or an unrelated stack
+- **Gluetun network containers (auto-managed)** — running containers using `network_mode: service:gluetun` are detected and recreated automatically after each switch, including those already stuck in a dead namespace (left over from a previously failed switch). Intentionally stopped containers stay stopped. Containers in a **different Compose stack** from Gluetun are also handled if their directory is accessible from Companion or if their `com.docker.compose` labels are present. Orphan detection is limited to containers referencing a **known former Gluetun** (ID history kept in the database) — Companion never touches dependents of another VPN or an unrelated stack
 - **Containers to restart after switch** — only for containers routing through Gluetun's HTTP/SOCKS5 proxy; ordered list (drag & drop)
 - **Pause during benchmark** — list of containers (torrent, Usenet…) stopped before the benchmark starts and automatically restarted when it ends, even on error
 - **Automatic Docker image updates** *(option)* — at switch time, Companion can update images before restarting containers: Gluetun itself, auto-managed network containers, post-switch containers and benchmark-paused containers; togglable per container from Settings

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ docker compose up -d
 
 Ouvrir **http://localhost:8765** — première connexion : entrez le compte à créer (enregistré automatiquement).
 
+> **Unraid / DockerMan :** un template XML temporaire est disponible dans [`templates/unraid`](templates/unraid/README.md) pour une installation manuelle ou via *Private Apps*, en attendant une éventuelle publication Community Applications.
+
 > **Companion dans la même stack que Gluetun ?**
 > Supprimez `extra_hosts` et utilisez le nom de service : `GLUETUN_HOST: gluetun`.
 > Lors d'une bascule, le companion cible uniquement le service Gluetun (`docker compose up -d <service>`) — il ne se recrée pas lui-même.
@@ -347,7 +349,7 @@ L'encart **Statut VPN** affiche l'intermédiaire et les opérateurs observés. D
 **Prérequis** — le sidecar catalogue a uniquement besoin d'un accès HTTPS sortant (réseau bridge Docker, activé par défaut). **Aucune modification de `docker-compose.yml` requise.**
 
 ### Gestion des containers Docker
-- **Containers réseau Gluetun (auto-gérés)** — tous les containers en `network_mode: service:gluetun` sont détectés et recréés automatiquement après chaque bascule, quel que soit leur état : containers encore fonctionnels **ou déjà dans un namespace mort** (suite à une bascule précédente ratée). Les containers dans une **stack Compose différente** de Gluetun sont également gérés si leur répertoire est accessible depuis Companion ou si leurs labels `com.docker.compose` sont présents. La détection d'orphelins est limitée aux containers référençant un **ancien Gluetun connu** (historique d'IDs en base) — Companion ne touche jamais aux dépendants d'un autre VPN ou d'une stack étrangère
+- **Containers réseau Gluetun (auto-gérés)** — les containers en cours d'exécution avec `network_mode: service:gluetun` sont détectés et recréés automatiquement après chaque bascule, y compris ceux déjà dans un namespace mort (suite à une bascule précédente ratée). Les containers volontairement stoppés restent stoppés. Les containers dans une **stack Compose différente** de Gluetun sont également gérés si leur répertoire est accessible depuis Companion ou si leurs labels `com.docker.compose` sont présents. La détection d'orphelins est limitée aux containers référençant un **ancien Gluetun connu** (historique d'IDs en base) — Companion ne touche jamais aux dépendants d'un autre VPN ou d'une stack étrangère
 - **Containers à redémarrer après bascule** — uniquement pour les containers utilisant le proxy HTTP/SOCKS5 de Gluetun ; liste ordonnée (glisser-déposer)
 - **Pause pendant le benchmark** — liste de containers (torrents, Usenet…) stoppés avant le début du benchmark et relancés automatiquement à la fin, même en cas d'erreur
 - **Mise à jour automatique des images Docker** *(option)* — au moment de la bascule, Companion peut mettre à jour les images avant de relancer les containers : Gluetun lui-même, les containers réseau auto-gérés, les containers à redémarrer après bascule et les containers en pause pendant le benchmark ; activable individuellement par container depuis les Paramètres

--- a/app/database.py
+++ b/app/database.py
@@ -527,6 +527,20 @@ def init_db(db_path: str):
                 "VALUES ('pf_auto_sync_default_migrated', '1')"
             )
 
+        # Allow fork/packaging templates to seed the matching sidecar image
+        # without overwriting users who changed it in the UI.
+        sidecar_image = (os.environ.get('SIDECAR_IMAGE') or '').strip()
+        if sidecar_image:
+            default_sidecar = 'ghcr.io/aerya/gluetun-companion-sidecar:latest'
+            row = db.execute(
+                "SELECT value FROM settings WHERE key='sidecar_image'"
+            ).fetchone()
+            if not row or (row['value'] or '').strip() == default_sidecar:
+                db.execute(
+                    "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+                    ('sidecar_image', sidecar_image),
+                )
+
 
 @contextmanager
 def get_db():

--- a/templates/unraid/README.md
+++ b/templates/unraid/README.md
@@ -1,0 +1,30 @@
+# Gluetun Companion Unraid template
+
+This folder contains the upstream DockerMan template for installing Gluetun
+Companion on Unraid.
+
+- `gluetun-companion.xml` points to the upstream `Aerya` GHCR image and `main`
+  branch URLs.
+- The template is suitable for manual DockerMan installs and can be reused as a
+  base for a later Community Applications submission.
+
+## Unraid-specific notes
+
+- Generate `SECRET_KEY` once with `openssl rand -hex 32`, paste it in the
+  template, and keep it unchanged for the life of the instance.
+- The container intentionally runs as root. Gluetun Companion must read and
+  write DockerMan templates under
+  `/boot/config/plugins/dockerMan/templates-user`, which are root-owned and
+  typically mode `600` on Unraid. Exposing `PUID`/`PGID` would be misleading
+  unless the user also changes host permissions manually.
+- The Docker socket mount is required for sidecar benchmarks, Docker event
+  monitoring and recreating running containers attached to Gluetun's network
+  namespace.
+- The DockerMan templates mount is required for persistent Unraid switches:
+  Companion writes Gluetun environment changes back to the Gluetun XML template
+  before recreating the container.
+- The Gluetun appdata mount is read-only and lets Companion import the local
+  `servers.json` used by the installed Gluetun container before falling back to
+  the public catalogue sidecar.
+- The WebUI entry uses `[PORT:8765]`, the container port, so Unraid follows any
+  host-port remap made by the user.

--- a/templates/unraid/gluetun-companion.xml
+++ b/templates/unraid/gluetun-companion.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>gluetun-companion</Name>
+  <Repository>ghcr.io/aerya/gluetun-companion:latest</Repository>
+  <Registry>https://github.com/Aerya/Gluetun-Companion/pkgs/container/gluetun-companion</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <MyMAC/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Aerya/Gluetun-Companion/issues</Support>
+  <Project>https://github.com/Aerya/Gluetun-Companion</Project>
+  <ReadMe>https://github.com/Aerya/Gluetun-Companion/blob/main/README.md</ReadMe>
+  <Overview>Gluetun Companion is a web UI that controls an existing Gluetun container: server catalogue, benchmarks, automatic/manual switches, Docker dependent recreation, VPN port forwarding rules, qBittorrent/rTorrent synchronization and Prometheus metrics.&#13;
+&#13;
+Unraid notes: this template is made for DockerMan-managed Gluetun containers. Companion needs read/write access to /boot/config/plugins/dockerMan/templates-user so server switches persist in the Unraid template XML. It also needs the Docker socket to inspect/recreate Gluetun and its running network dependents. Because DockerMan templates are root-owned and mode 600 on Unraid, the container intentionally runs as root; PUID/PGID are not exposed because they would break template write-back unless the host permissions are changed manually.&#13;
+&#13;
+Before first start, set SECRET_KEY to a long random value and keep it forever. Changing it later makes encrypted VPN credentials unreadable. Example: openssl rand -hex 32</Overview>
+  <Category>Tools:Network:VPN</Category>
+  <WebUI>http://[IP]:[PORT:8765]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/Aerya/Gluetun-Companion/main/templates/unraid/gluetun-companion.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Aerya/Gluetun-Companion/main/assets/logo.png</Icon>
+  <ExtraParams>--add-host=host.docker.internal:host-gateway --restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires>Existing Gluetun container managed by Unraid DockerMan. Gluetun HTTP proxy is recommended for proxy tests; Gluetun Control Server is required for native port forwarding synchronization.</Requires>
+  <Config Name="WebUI" Target="8765" Default="8765" Mode="tcp" Description="Gluetun Companion web interface. The WebUI entry intentionally references the container port so Unraid follows any host port remap." Type="Port" Display="always" Required="true" Mask="false">8765</Config>
+  <Config Name="Appdata" Target="/data" Default="/mnt/user/appdata/gluetun-companion" Mode="rw" Description="Persistent Companion database, encrypted VPN profiles, benchmark history and settings." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/gluetun-companion</Config>
+  <Config Name="Docker Socket" Target="/var/run/docker.sock" Default="/var/run/docker.sock" Mode="rw" Description="Required to inspect Gluetun, create sidecar test containers, watch Docker events and recreate running containers attached to Gluetun network namespace." Type="Path" Display="always" Required="true" Mask="false">/var/run/docker.sock</Config>
+  <Config Name="Unraid DockerMan templates" Target="/boot/config/plugins/dockerMan/templates-user" Default="/boot/config/plugins/dockerMan/templates-user" Mode="rw" Description="Required in Unraid mode. Companion updates the Gluetun DockerMan XML template so VPN switches persist across Unraid recreates/updates." Type="Path" Display="always" Required="true" Mask="false">/boot/config/plugins/dockerMan/templates-user</Config>
+  <Config Name="Gluetun appdata" Target="/gluetun" Default="/mnt/user/appdata/gluetun" Mode="ro" Description="Read-only access to Gluetun local server catalogues, especially /gluetun/servers.json and /gluetun/servers/*.json. This lets Companion import the exact server list used by the installed Gluetun container instead of falling back to the public GitHub catalogue." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/gluetun</Config>
+  <Config Name="Custom OpenVPN config folder" Target="/openvpn" Default="/mnt/user/appdata/gluetun/openvpn" Mode="rw" Description="Optional. Folder where Companion can store uploaded Custom OpenVPN profiles. It should be the same host folder mounted into Gluetun." Type="Path" Display="advanced" Required="false" Mask="false">/mnt/user/appdata/gluetun/openvpn</Config>
+  <Config Name="SECRET_KEY" Target="SECRET_KEY" Default="" Mode="" Description="Required. Generate once with: openssl rand -hex 32. Keep it stable; changing it makes encrypted VPN credentials unreadable." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Timezone" Target="TZ" Default="Europe/Paris" Mode="" Description="Timezone used for logs and UI timestamps." Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+  <Config Name="Gluetun container name" Target="GLUETUN_CONTAINER" Default="gluetun" Mode="" Description="Exact name of the existing Gluetun container managed by Unraid DockerMan." Type="Variable" Display="always" Required="true" Mask="false">gluetun</Config>
+  <Config Name="Gluetun proxy host" Target="GLUETUN_HOST" Default="host.docker.internal" Mode="" Description="Host used by Companion to reach Gluetun HTTP proxy from inside this container. For the standard Unraid bridge setup, keep host.docker.internal." Type="Variable" Display="always" Required="true" Mask="false">host.docker.internal</Config>
+  <Config Name="Gluetun HTTP proxy host port" Target="GLUETUN_PROXY_PORT" Default="8888" Mode="" Description="Host port published by Gluetun for its HTTP proxy. Used for proxy quick checks and public IP detection. Match the host port mapped to Gluetun container port 8888." Type="Variable" Display="always" Required="true" Mask="false">8888</Config>
+  <Config Name="Sidecar image" Target="SIDECAR_IMAGE" Default="ghcr.io/aerya/gluetun-companion-sidecar:latest" Mode="" Description="Sidecar image used for speed tests and catalogue imports. Keep it aligned with the Companion image tag." Type="Variable" Display="always" Required="true" Mask="false">ghcr.io/aerya/gluetun-companion-sidecar:latest</Config>
+  <Config Name="DATA_DIR" Target="DATA_DIR" Default="/data" Mode="" Description="Internal data directory. Do not change unless you also change the Appdata mount target." Type="Variable" Display="advanced" Required="true" Mask="false">/data</Config>
+  <Config Name="COMPOSE_DIR" Target="COMPOSE_DIR" Default="/compose" Mode="" Description="Internal compose directory for non-Unraid compose mode. DockerMan-managed Unraid Gluetun containers do not need this mount." Type="Variable" Display="advanced" Required="false" Mask="false">/compose</Config>
+  <Config Name="OPENVPN_CONFIG_DIR" Target="OPENVPN_CONFIG_DIR" Default="/openvpn" Mode="" Description="Internal path where Companion writes uploaded Custom OpenVPN files." Type="Variable" Display="advanced" Required="false" Mask="false">/openvpn</Config>
+  <Config Name="OPENVPN_CONTAINER_DIR" Target="OPENVPN_CONTAINER_DIR" Default="/gluetun/openvpn" Mode="" Description="Path where the same OpenVPN folder is visible from inside the Gluetun container." Type="Variable" Display="advanced" Required="false" Mask="false">/gluetun/openvpn</Config>
+  <Config Name="UNRAID_TEMPLATE_DIR" Target="UNRAID_TEMPLATE_DIR" Default="/boot/config/plugins/dockerMan/templates-user" Mode="" Description="Internal path to Unraid DockerMan user templates. Keep aligned with the DockerMan templates mount target." Type="Variable" Display="advanced" Required="false" Mask="false">/boot/config/plugins/dockerMan/templates-user</Config>
+  <Config Name="METRICS_TOKEN" Target="METRICS_TOKEN" Default="" Mode="" Description="Optional Bearer token for /metrics. Leave empty for LAN-only Prometheus scraping or set a strong token if exposed through a reverse proxy." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="LOG_LEVEL" Target="LOG_LEVEL" Default="INFO" Mode="" Description="Logging verbosity: INFO for normal use, DEBUG while troubleshooting." Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>
+  <Config Name="LOG_JSON" Target="LOG_JSON" Default="0" Mode="" Description="Set to 1 to emit structured JSON logs." Type="Variable" Display="advanced" Required="false" Mask="false">0</Config>
+  <TailscaleStateDir/>
+</Container>

--- a/tests/test_unraid_template.py
+++ b/tests/test_unraid_template.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from unittest.mock import patch
 from app.unraid import find_template, update_template_env, write_template_env
 
 FIXTURE = Path(__file__).parent / 'fixtures' / 'my-gluetun.xml'
+UNRAID_TEMPLATE = Path(__file__).resolve().parents[1] / 'templates' / 'unraid' / 'gluetun-companion.xml'
 
 
 def _val(text, name):
@@ -94,6 +96,22 @@ class WriteTemplateEnvTest(unittest.TestCase):
             changed = write_template_env(path, [('VPN_SERVICE_PROVIDER', 'protonvpn')])
             self.assertEqual(changed, [])
             self.assertEqual([f for f in os.listdir(d) if '.bak-' in f], [])
+
+
+class DockerManTemplateFileTest(unittest.TestCase):
+    def test_upstream_template_is_parseable_and_not_fork_specific(self):
+        text = UNRAID_TEMPLATE.read_text(encoding='utf-8')
+        root = ET.fromstring(text)
+        self.assertEqual(root.findtext('Repository'), 'ghcr.io/aerya/gluetun-companion:latest')
+        self.assertNotIn('Hugs11', text)
+        self.assertNotIn('fork-test', text)
+        targets = {
+            node.attrib.get('Target')
+            for node in root.findall('Config')
+        }
+        self.assertIn('/gluetun', targets)
+        self.assertNotIn('PUID', targets)
+        self.assertNotIn('PGID', targets)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Stacked on #53, #54, #55 (all merged). Final PR of the Unraid/ProtonVPN series.

Adds the Unraid Docker template for Companion:
- `templates/unraid/gluetun-companion.xml` — Community-Apps-style template (Aerya image/namespace), with the `host.docker.internal:host-gateway` mapping and SIDECAR_IMAGE wiring.
- `templates/unraid/README.md` — install notes.
- `app/database.py`: seed the `sidecar_image` setting from the `SIDECAR_IMAGE` env when the user hasn't customised it (still at the aerya default) — non-destructive.
- `.github/workflows/docker-publish.yml`: derive the image namespace from the repo owner (no-op for Aerya, lets forks publish their own image) + manual `workflow_dispatch`.
- Test: template sanity (`test_unraid_template.py`).

Compose backend behaviour is unchanged.
