### PR TITLE
fix(catalogue): utiliser le catalogue Gluetun monté

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -332,20 +332,20 @@ The **VPN Status** card displays the intermediary and observed operators. In tab
 ---
 
 ### Gluetun server catalogue
-- **GitHub download** — the catalogue Sidecar downloads server lists directly from the public [`qdm12/gluetun-servers`](https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers) repository; **no volume to mount**, no changes to your Gluetun configuration required
+- **Real Gluetun catalogue first** — the catalogue Sidecar automatically mounts the Gluetun container's `/gluetun` volume when it is available and reads `/gluetun/servers.json` first; this is the exact list loaded by Gluetun. If that volume is not available, Companion falls back to the public [`qdm12/gluetun-servers`](https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers) repository
 - **Automatic refresh** — the list is updated **at every benchmark cycle** (configurable interval in Settings → Measure, default: 6 h); a dedicated button in Settings and in the `/servers` modal lets you force an immediate refresh
 - **Auto-add new servers** *(option)* — when new servers appear in the catalogue for a **country**, **region** or **city** you already have configured, Companion automatically adds them to your server list (as `SERVER_NAMES` entries) without any manual action; disabled by default, enable in **Settings → Maintenance → Catalogue**
 - **Change notifications** *(option)* — Discord/Apprise alert sent on each refresh when servers are added to or removed from the catalogue, with per-provider detail (+N/−N); enable in **Settings → Notifications**
 - **3 import modes in Settings**:
-  1. **All providers** — imports servers from every provider available on GitHub
+  1. **All providers** — imports servers from every provider available in the local Gluetun catalogue, or from the GitHub fallback
   2. **Chosen provider** — imports only the servers of a provider selected manually
   3. **Active provider** — automatically detects the provider configured in your Gluetun and imports its servers only
   — for each mode, an option to **run a full benchmark** immediately after import (using the configured method in Settings, across all servers in the list)
 - **All filter types** — each server is imported with its full attributes: `SERVER_NAMES`, `SERVER_COUNTRIES`, `SERVER_CITIES`, `SERVER_REGIONS`, `SERVER_HOSTNAMES`
 - **Multi-filter selection from `/servers`** — select servers by freely mixing filter types (e.g. names + countries + cities at the same time); Companion applies the right filter in Gluetun and changes the filter type on the fly if needed
-- ⚠️ **ProtonVPN** — Free ProtonVPN servers are available via the **Catalogue**. To access Premium servers, use **Import from Gluetun** to retrieve the servers already configured in your Gluetun compose (paid account required).
+- ⚠️ **ProtonVPN** — When the Gluetun container's `/gluetun` volume is available, the **Catalogue** uses `servers.json` and can therefore show the Premium servers actually loaded by Gluetun, including P2P/Streaming/hostname metadata. Without that volume, the GitHub fallback may still be limited to public data.
 
-**Prerequisites** — the catalogue sidecar only needs outbound HTTPS access (Docker bridge network, enabled by default). **No `docker-compose.yml` changes required.**
+**Prerequisites** — the catalogue sidecar works without extra configuration. To enrich the catalogue with the data actually loaded by Gluetun, Companion tries to mount the Gluetun container's `/gluetun` volume read-only; otherwise outbound HTTPS access is enough for the GitHub fallback.
 
 ### Docker container management
 - **Gluetun network containers (auto-managed)** — all containers using `network_mode: service:gluetun` are detected and recreated automatically after each switch, regardless of their state: containers still functional **or already stuck in a dead namespace** (left over from a previously failed switch). Containers in a **different Compose stack** from Gluetun are also handled if their directory is accessible from Companion or if their `com.docker.compose` labels are present. Orphan detection is limited to containers referencing a **known former Gluetun** (ID history kept in the database) — Companion never touches dependents of another VPN or an unrelated stack

--- a/README.md
+++ b/README.md
@@ -331,20 +331,20 @@ L'encart **Statut VPN** affiche l'intermédiaire et les opérateurs observés. D
 ---
 
 ### Catalogue de serveurs Gluetun
-- **Téléchargement GitHub** — le Sidecar catalogue télécharge les listes de serveurs directement depuis le dépôt public [`qdm12/gluetun-servers`](https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers) ; **aucun volume à monter**, aucune modification de votre configuration Gluetun requise
+- **Catalogue réel Gluetun en priorité** — le Sidecar catalogue monte automatiquement le volume `/gluetun` du container Gluetun quand il est accessible et lit `/gluetun/servers.json` en priorité ; ce fichier correspond à la liste réellement chargée par Gluetun. Si ce volume n'est pas disponible, Companion retombe sur le dépôt public [`qdm12/gluetun-servers`](https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers)
 - **Mise à jour automatique** — la liste est rafraîchie **à chaque cycle de benchmark** (intervalle configurable dans Paramètres → Mesurer, défaut : 6 h) ; un bouton dédié dans les Paramètres et dans le modal `/servers` permet de forcer une mise à jour immédiate
 - **Auto-ajout des nouveaux serveurs** *(option)* — quand de nouveaux serveurs apparaissent dans le catalogue pour un **pays**, une **région** ou une **ville** que vous avez déjà configuré, Companion les ajoute automatiquement à votre liste (type `SERVER_NAMES`) sans intervention manuelle ; désactivé par défaut, activable dans **Paramètres → Maintenance → Catalogue**
 - **Notification de changements** *(option)* — Discord/Apprise envoyés à chaque refresh si des serveurs sont ajoutés ou supprimés du catalogue, avec le détail par provider (+N/-N) ; activable dans **Paramètres → Notifications**
 - **3 modes d'import dans les Paramètres** :
-  1. **Tous les providers** — importe les serveurs de tous les providers disponibles sur GitHub
+  1. **Tous les providers** — importe les serveurs de tous les providers disponibles dans le catalogue local Gluetun, ou dans le fallback GitHub
   2. **Provider au choix** — importe uniquement les serveurs du provider sélectionné manuellement
   3. **Provider actif** — détecte automatiquement le provider configuré dans votre Gluetun et n'importe que ses serveurs
   — pour chacun de ces modes, option de **lancer un benchmark complet** immédiatement après l'import (méthode configurée dans Paramètres, sur tous les serveurs de la liste)
 - **Tous les types de filtre** — chaque serveur est importé avec ses attributs complets : `SERVER_NAMES`, `SERVER_COUNTRIES`, `SERVER_CITIES`, `SERVER_REGIONS`, `SERVER_HOSTNAMES`
 - **Sélection multi-filtre depuis `/servers`** — sélectionnez des serveurs en mixant librement les types de filtre (ex : noms + pays + villes simultanément) ; Companion applique le bon filtre dans Gluetun et change le type à la volée si nécessaire
-- ⚠️ **ProtonVPN** — Les serveurs gratuits ProtonVPN sont disponibles via le **Catalogue**. Pour accéder aux serveurs Premium, utilisez **Importer depuis Gluetun** afin de récupérer les serveurs déjà configurés dans votre compose Gluetun (compte payant requis).
+- ⚠️ **ProtonVPN** — Quand le volume `/gluetun` du container Gluetun est accessible, le **Catalogue** utilise `servers.json` et peut donc afficher les serveurs Premium réellement chargés par Gluetun, avec leurs métadonnées P2P/Streaming/hostname. Sans ce volume, le fallback GitHub peut rester limité aux données publiques.
 
-**Prérequis** — le sidecar catalogue a uniquement besoin d'un accès HTTPS sortant (réseau bridge Docker, activé par défaut). **Aucune modification de `docker-compose.yml` requise.**
+**Prérequis** — le sidecar catalogue fonctionne sans configuration supplémentaire. Pour enrichir le catalogue avec les données réellement chargées par Gluetun, Companion tente de monter automatiquement le volume `/gluetun` du container Gluetun en lecture seule ; sinon un accès HTTPS sortant suffit pour le fallback GitHub.
 
 ### Gestion des containers Docker
 - **Containers réseau Gluetun (auto-gérés)** — tous les containers en `network_mode: service:gluetun` sont détectés et recréés automatiquement après chaque bascule, quel que soit leur état : containers encore fonctionnels **ou déjà dans un namespace mort** (suite à une bascule précédente ratée). Les containers dans une **stack Compose différente** de Gluetun sont également gérés si leur répertoire est accessible depuis Companion ou si leurs labels `com.docker.compose` sont présents. La détection d'orphelins est limitée aux containers référençant un **ancien Gluetun connu** (historique d'IDs en base) — Companion ne touche jamais aux dépendants d'un autre VPN ou d'une stack étrangère

--- a/app/catalogue.py
+++ b/app/catalogue.py
@@ -648,14 +648,14 @@ def refresh_catalogue_from_sidecar(
     sidecar_host: str,
     catalogue_port: int = 8767,
     auto_add: bool = False,
+    gluetun_container_name: str | None = None,
 ) -> dict:
     """
     Spin up a catalogue-only sidecar container, call its /catalogue endpoint,
     save the results to gluetun_catalogue, then destroy the container.
 
-    The sidecar fetches server lists from the public Gluetun GitHub repository:
-      https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers
-    No volume mounting or Gluetun API required — pure HTTPS download.
+    The sidecar prefers the real Gluetun /gluetun volume when available, then
+    falls back to the public Gluetun GitHub repository.
 
     Returns {ok, total, providers, diff, auto_added} or {ok: False, error}.
 
@@ -673,7 +673,10 @@ def refresh_catalogue_from_sidecar(
     token = secrets.token_hex(32)
 
     # ── 1. Create sidecar ────────────────────────────────────────────────────
-    ok, err = create_catalogue_sidecar(sidecar_image, catalogue_port, token=token)
+    ok, err = create_catalogue_sidecar(
+        sidecar_image, catalogue_port, token=token,
+        gluetun_container_name=gluetun_container_name,
+    )
     if not ok:
         logger.error('refresh_catalogue_from_sidecar: sidecar creation failed: %s', err)
         return {'ok': False, 'error': f'Sidecar creation failed: {err}'}

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -1658,13 +1658,13 @@ def create_catalogue_sidecar(
     sidecar_image: str,
     port: int = _CATALOGUE_SIDECAR_PORT,
     token: str = '',
+    gluetun_container_name: str | None = None,
 ) -> tuple[bool, str | None]:
     """
     Create a standalone sidecar container (bridge network, internet access).
-    The sidecar fetches server lists from the public Gluetun GitHub repository:
-      https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers
-
-    No volume mounting required — the sidecar only needs outbound HTTPS.
+    When possible, mount the real Gluetun /gluetun volume read-only so the
+    sidecar can read /gluetun/servers.json (the exact catalogue Gluetun loaded).
+    It falls back to the public Gluetun GitHub catalogue when no volume is found.
 
     *token* is passed as SIDECAR_SECRET env var so all sidecar endpoints
     require it on every request.  Generate with secrets.token_hex(32) in
@@ -1681,19 +1681,43 @@ def create_catalogue_sidecar(
         env: dict[str, str] = {}
         if token:
             env['SIDECAR_SECRET'] = token
+        volumes: dict[str, dict[str, str]] = {}
+        if gluetun_container_name:
+            try:
+                real = client.containers.get(gluetun_container_name)
+                attrs = real.attrs
+                for mount in attrs.get('Mounts') or []:
+                    if (mount.get('Destination') or '').rstrip('/') == '/gluetun':
+                        source = mount.get('Source') or mount.get('Name') or ''
+                        if source:
+                            volumes[source] = {'bind': '/gluetun', 'mode': 'ro'}
+                            break
+                if not volumes:
+                    for bind in attrs.get('HostConfig', {}).get('Binds') or []:
+                        parts = bind.split(':')
+                        if len(parts) >= 2 and parts[1].rstrip('/') == '/gluetun':
+                            volumes[parts[0]] = {'bind': '/gluetun', 'mode': 'ro'}
+                            break
+            except Exception as exc:
+                logger.warning(
+                    'Catalogue sidecar: cannot inspect Gluetun volume from %s: %s',
+                    gluetun_container_name, exc,
+                )
 
         client.containers.run(
             image=sidecar_image,
             name=_CATALOGUE_SIDECAR_NAME,
             network_mode='bridge',
             environment=env,
+            volumes=volumes or None,
             ports={'8766/tcp': port},
             detach=True,
             remove=False,
         )
         logger.info(
-            'Catalogue sidecar started: %s (port: %d, auth: %s)',
+            'Catalogue sidecar started: %s (port: %d, auth: %s, gluetun_volume: %s)',
             _CATALOGUE_SIDECAR_NAME, port, 'yes' if token else 'no',
+            'yes' if volumes else 'no',
         )
         return True, None
     except Exception as exc:

--- a/app/routes.py
+++ b/app/routes.py
@@ -3146,6 +3146,7 @@ def api_catalogue_refresh():
     result = refresh_catalogue_from_sidecar(
         sidecar_image=sidecar_image,
         sidecar_host=sidecar_host,
+        gluetun_container_name=current_app.config['GLUETUN_CONTAINER'],
     )
     return jsonify(result), (200 if result.get('ok') else 500)
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1137,6 +1137,7 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
             _cat = refresh_catalogue_from_sidecar(
                 sidecar_image=_sidecar_img,
                 sidecar_host=_sidecar_host,
+                gluetun_container_name=app.config['GLUETUN_CONTAINER'],
                 auto_add=_cat_auto_add,
             )
         if _cat.get('ok'):

--- a/sidecar/app.py
+++ b/sidecar/app.py
@@ -54,6 +54,7 @@ import os
 import re
 import subprocess
 import time
+import glob
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from statistics import median
 
@@ -73,6 +74,7 @@ _CAT_EXCLUDED: set[str] = set()
 # No volume mounting or Gluetun API required — pure HTTP download.
 _GITHUB_API_URL = 'https://api.github.com/repos/qdm12/gluetun-servers/contents/pkg/servers'
 _GITHUB_RAW_URL = 'https://raw.githubusercontent.com/qdm12/gluetun-servers/main/pkg/servers'
+_LOCAL_GLUETUN_DIR = os.environ.get('GLUETUN_DIR', '/gluetun')
 # Shared secret — Companion generates a random token per sidecar instance and
 # passes it via SIDECAR_SECRET env var.  All endpoints require it when set.
 _SECRET       = os.environ.get('SIDECAR_SECRET', '')
@@ -103,6 +105,109 @@ def _server_types_from_raw(server: dict) -> str:
         key for key, field in _SERVER_TYPE_FIELDS.items()
         if bool(server.get(field))
     )
+
+
+def _ips_from_raw(server: dict) -> str:
+    raw = server.get('ips') or []
+    if isinstance(raw, str):
+        raw = [part.strip() for part in raw.replace(';', ',').split(',')]
+    elif not isinstance(raw, (list, tuple, set)):
+        raw = []
+    ips: list[str] = []
+    for item in raw:
+        value = str(item or '').strip()
+        if value and value not in ips:
+            ips.append(value)
+    return json.dumps(ips, separators=(',', ':')) if ips else ''
+
+
+def _normalize_server_list(raw_servers: list[dict]) -> list[dict]:
+    normalized_by_name: dict[str, dict] = {}
+    normalized_extra: list[dict] = []
+    for s in raw_servers:
+        hostnames = s.get('hostnames') or []
+        hostname = s.get('hostname') or (hostnames[0] if hostnames else '')
+        srv = {
+            'name':         s.get('name') or s.get('server_name') or '',
+            'country':      s.get('country') or '',
+            'country_code': (s.get('country_code') or s.get('countryCode') or '').lower(),
+            'region':       s.get('region') or '',
+            'city':         s.get('city') or '',
+            'hostname':     hostname or '',
+            'ips':          _ips_from_raw(s),
+            'port_forward': bool(s.get('port_forward')),
+            'server_types':  _server_types_from_raw(s),
+        }
+        if any(v for k, v in srv.items() if k != 'port_forward'):
+            if srv['name']:
+                existing = normalized_by_name.get(srv['name'])
+                if existing:
+                    existing['port_forward'] = bool(existing.get('port_forward') or srv['port_forward'])
+                    existing_types = {
+                        t for t in (existing.get('server_types') or '').split(',') if t
+                    }
+                    existing_types.update(t for t in (srv.get('server_types') or '').split(',') if t)
+                    existing['server_types'] = ','.join(
+                        t for t in _SERVER_TYPE_FIELDS if t in existing_types
+                    )
+                    if not existing.get('hostname') and srv.get('hostname'):
+                        existing['hostname'] = srv['hostname']
+                    if not existing.get('ips') and srv.get('ips'):
+                        existing['ips'] = srv['ips']
+                else:
+                    normalized_by_name[srv['name']] = srv
+            else:
+                normalized_extra.append(srv)
+    return list(normalized_by_name.values()) + normalized_extra
+
+
+def _read_mounted_catalogue(root: str = _LOCAL_GLUETUN_DIR) -> dict[str, list[dict]]:
+    """Read Gluetun's mounted catalogue, preferring the loaded aggregate file.
+
+    `/gluetun/servers.json` is the catalogue Gluetun actually loaded and can
+    contain Proton premium servers missing from the public provider JSON files.
+    """
+    result: dict[str, list[dict]] = {}
+    aggregate = os.path.join(root, 'servers.json')
+    if os.path.isfile(aggregate):
+        try:
+            with open(aggregate, encoding='utf-8') as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                for provider, provider_data in data.items():
+                    if provider == 'version' or provider in _CAT_EXCLUDED:
+                        continue
+                    servers = provider_data.get('servers', []) if isinstance(provider_data, dict) else []
+                    normalized = _normalize_server_list(servers)
+                    if normalized:
+                        result[provider.lower()] = normalized
+        except Exception as exc:
+            logger.warning('catalogue: cannot read mounted aggregate %s: %s', aggregate, exc)
+        if result:
+            return result
+
+    for directory in (root, os.path.join(root, 'servers')):
+        if not os.path.isdir(directory):
+            continue
+        for path in sorted(glob.glob(os.path.join(directory, '*.json'))):
+            fname = os.path.basename(path)
+            if fname == 'manifest.json':
+                continue
+            provider = fname[:-5].lower()
+            if provider in _CAT_EXCLUDED:
+                continue
+            try:
+                with open(path, encoding='utf-8') as fh:
+                    data = json.load(fh)
+                normalized = _normalize_server_list(data.get('servers', []))
+            except Exception as exc:
+                logger.warning('catalogue: cannot read mounted provider %s: %s', path, exc)
+                continue
+            if normalized:
+                result[provider] = normalized
+        if result:
+            return result
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -154,15 +259,22 @@ def ready():
 @app.route('/catalogue')
 def catalogue():
     """
-    Download per-provider server JSON files from the public Gluetun repository:
-      https://github.com/qdm12/gluetun-servers/tree/main/pkg/servers
+    Return the Gluetun server catalogue.
 
-    No volume mounting, no Gluetun API — pure public HTTPS download.
+    Prefer a mounted /gluetun/servers.json from the user's Gluetun container
+    (the exact catalogue Gluetun loaded), then fall back to the public
+    gluetun-servers repository for installs without that volume.
     Requires X-Sidecar-Token header when SIDECAR_SECRET is set.
     Called by the Companion at the start of each benchmark cycle and on
     manual catalogue refresh.
     """
     _require_auth()
+
+    local = _read_mounted_catalogue()
+    if local:
+        total = sum(len(v) for v in local.values())
+        logger.info('catalogue: total %d servers from mounted Gluetun catalogue', total)
+        return jsonify({'ok': True, 'providers': local, 'source': 'local'})
 
     # ── 1. List available provider files via GitHub API ──────────────────────
     try:
@@ -204,43 +316,7 @@ def catalogue():
             logger.warning('catalogue: cannot fetch %s: %s', fname, exc)
             continue
 
-        raw_servers = data.get('servers', [])
-        normalized_by_name: dict[str, dict] = {}
-        normalized_extra: list[dict] = []
-        for s in raw_servers:
-            hostnames = s.get('hostnames') or []
-            hostname  = s.get('hostname') or (hostnames[0] if hostnames else '')
-            srv = {
-                'name':         s.get('name') or s.get('server_name') or '',
-                'country':      s.get('country') or '',
-                'country_code': (s.get('country_code') or s.get('countryCode') or '').lower(),
-                'region':       s.get('region') or '',
-                'city':         s.get('city') or '',
-                'hostname':     hostname or '',
-                'port_forward': bool(s.get('port_forward')),
-                'server_types':  _server_types_from_raw(s),
-            }
-            if any(v for k, v in srv.items() if k != 'port_forward'):
-                if srv['name']:
-                    existing = normalized_by_name.get(srv['name'])
-                    if existing:
-                        existing['port_forward'] = bool(existing.get('port_forward') or srv['port_forward'])
-                        existing_types = {
-                            t for t in (existing.get('server_types') or '').split(',') if t
-                        }
-                        existing_types.update(t for t in (srv.get('server_types') or '').split(',') if t)
-                        existing['server_types'] = ','.join(
-                            t for t in _SERVER_TYPE_FIELDS if t in existing_types
-                        )
-                        if not existing.get('hostname') and srv.get('hostname'):
-                            existing['hostname'] = srv['hostname']
-                    else:
-                        normalized_by_name[srv['name']] = srv
-                else:
-                    normalized_extra.append(srv)
-
-        normalized = list(normalized_by_name.values()) + normalized_extra
-
+        normalized = _normalize_server_list(data.get('servers', []))
         if normalized:
             result[provider] = normalized
             logger.info('catalogue: %s → %d servers', provider, len(normalized))

--- a/tests/test_sidecar_catalogue.py
+++ b/tests/test_sidecar_catalogue.py
@@ -1,0 +1,59 @@
+"""Unit tests for the sidecar catalogue reader."""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_SIDECAR_PATH = Path(__file__).resolve().parents[1] / 'sidecar' / 'app.py'
+_spec = importlib.util.spec_from_file_location('sidecar_app_catalogue', _SIDECAR_PATH)
+sidecar = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sidecar)
+
+
+class MountedCatalogueTest(unittest.TestCase):
+    def test_prefers_aggregate_servers_json_with_proton_premium_metadata(self):
+        with TemporaryDirectory() as d:
+            payload = {
+                'version': 1,
+                'protonvpn': {
+                    'servers': [
+                        {
+                            'server_name': 'FR#208',
+                            'country': 'France',
+                            'city': 'Marseille',
+                            'hostname': 'node-fr-24.protonvpn.net',
+                            'port_forward': True,
+                            'stream': True,
+                        },
+                    ],
+                },
+            }
+            provider = {
+                'servers': [
+                    {
+                        'server_name': 'FR#999',
+                        'country': 'France',
+                        'hostname': 'node-fr-99.protonvpn.net',
+                    },
+                ],
+            }
+            servers_dir = Path(d) / 'servers'
+            servers_dir.mkdir()
+            (Path(d) / 'servers.json').write_text(json.dumps(payload), encoding='utf-8')
+            (servers_dir / 'protonvpn.json').write_text(json.dumps(provider), encoding='utf-8')
+
+            data = sidecar._read_mounted_catalogue(d)
+
+        self.assertEqual(set(data), {'protonvpn'})
+        self.assertEqual(len(data['protonvpn']), 1)
+        server = data['protonvpn'][0]
+        self.assertEqual(server['name'], 'FR#208')
+        self.assertEqual(server['city'], 'Marseille')
+        self.assertEqual(server['hostname'], 'node-fr-24.protonvpn.net')
+        self.assertEqual(server['server_types'], 'p2p,stream')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Résumé

Cette PR corrige l’enrichissement du catalogue ProtonVPN quand Companion ne voit pas directement le volume `/gluetun`.

Le sidecar catalogue monte maintenant le volume `/gluetun` du conteneur Gluetun en lecture seule quand c’est possible, puis lit `/gluetun/servers.json` en priorité. Ce fichier agrégé correspond à la liste réellement chargée par Gluetun et contient des serveurs Proton premium absents du JSON public récupéré depuis GitHub.

## Cause

Sur l’installation testée, Companion ne montait pas `/gluetun`, donc le refresh local échouait et l’app retombait sur le sidecar catalogue. Ce sidecar ne lisait que la liste publique `gluetun-servers` depuis GitHub. Certains serveurs Proton configurés comme `FR#208`, `FR#133` ou `FR#109` existaient bien dans le `servers.json` réel de Gluetun, mais pas dans le `protonvpn.json` public sous ces noms. Résultat : pas de correspondance dans `gluetun_catalogue`, donc pas de badges P2P/Streaming ni de détail ville/hostname dans l’UI.

## Changements

- Monte le volume `/gluetun` du vrai conteneur Gluetun dans le sidecar catalogue quand disponible.
- Priorise `/gluetun/servers.json` dans l’endpoint `/catalogue` du sidecar.
- Conserve le fallback GitHub pour les installations sans volume Gluetun accessible.
- Passe le nom du conteneur Gluetun depuis les refresh manuels et planifiés.
- Ajoute un test unitaire couvrant le cas Proton premium depuis `servers.json`.

## Validation

- `python -m pytest tests/test_catalogue_port_forward.py tests/test_sidecar_catalogue.py`
- Validé sur Unraid : après refresh depuis le `servers.json` réel, les serveurs `FR#208`, `FR#133`, `FR#109`, etc. récupèrent bien `p2p,stream`, la ville et le hostname.