### PR TITLE
Documente l’exception Trivy pour Docker Compose

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -40,6 +40,7 @@ jobs:
           output: trivy-companion.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
 
       - name: Trivy — Sidecar (SARIF)
         uses: aquasecurity/trivy-action@v0.36.0
@@ -49,6 +50,7 @@ jobs:
           output: trivy-sidecar.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -65,6 +67,7 @@ jobs:
           output: trivy-companion.json
           severity: HIGH,CRITICAL
           ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
 
       - name: Trivy — Sidecar (JSON)
         uses: aquasecurity/trivy-action@v0.36.0
@@ -74,6 +77,7 @@ jobs:
           output: trivy-sidecar.json
           severity: HIGH,CRITICAL
           ignore-unfixed: false
+          trivyignores: .trivyignore.yaml
 
       - name: Compute Dockerfile fixes
         id: fix

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,9 @@
+vulnerabilities:
+  - id: CVE-2026-34040
+    purls:
+      - pkg:golang/github.com/docker/docker@v28.5.2+incompatible
+    expired_at: 2027-07-11
+    statement: >-
+      The Companion image embeds Docker CLI and Docker Compose, not Docker Engine.
+      This CVE only affects Engine deployments using an AuthZ plugin. Reassess when
+      Compose migrates away from the deprecated github.com/docker/docker module.


### PR DESCRIPTION
## Résumé

- supprime de manière ciblée CVE-2026-34040 du scan Trivy du paquet github.com/docker/docker@v28.5.2+incompatible ;
- documente la justification et fixe une expiration au 11 juillet 2027 ;
- applique cette règle aux sorties SARIF et JSON afin d’éviter la réouverture de l’issue #16.

## Justification

L’image Companion embarque Docker CLI et Docker Compose, pas Docker Engine. Ce CVE concerne le démon Docker lorsqu’un plugin AuthZ est configuré. La montée vers 29.3.1 n’est pas applicable : Docker v29 a retiré le module github.com/docker/docker, tandis que Compose 5.1.4 y dépend encore.

## Validation

- python -m compileall -q app
- python -m unittest discover -s tests -v (98 tests)
- git diff --check
- build et smoke test GitHub en attente