### PR TITLE
Corrige le suivi Trivy de Docker Compose

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -128,10 +128,13 @@ jobs:
                   data = json.loads(pathlib.Path(f).read_text())
               except Exception:
                   continue
+              seen = set()
               for result in data.get('Results', []):
-                  for v in result.get('Vulnerabilities', []):
-                      if v.get('FixedVersion'):
-                          total += 1
+                for v in result.get('Vulnerabilities', []):
+                  cve_id = v.get('VulnerabilityID')
+                  if v.get('FixedVersion') and cve_id and cve_id not in seen:
+                      seen.add(cve_id)
+                      total += 1
 
           with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
               out.write(f'total={total}\n')

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM docker:29.6.1-cli AS docker-bin
 # binaire précompilé embarque encore containerd v2.2.3 et Go 1.26.3. On garde
 # donc la même version fonctionnelle de Compose, recompilée avec les versions
 # corrigées signalées par Trivy.
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS compose-bin
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS compose-bin
 
 ARG TARGETOS=linux
 ARG TARGETARCH


### PR DESCRIPTION
## Résumé

- met à jour Go de 1.26.4 à 1.26.5, version corrigée pour CVE-2026-39822 ;
- déduplique les CVE par image avant de décider d’ouvrir ou mettre à jour une issue ;
- complète l’exception ciblée déjà appliquée à CVE-2026-34040.

## Validation

- python -m compileall -q app
- python -m unittest discover -s tests -v (98 tests)
- git diff --check
- builds, smoke test et scan Trivy GitHub en attente