### PR TITLE
Fiabilise le serveur actif, l’historique et le réseau Gluetun

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -353,7 +353,7 @@ The **VPN Status** card displays the intermediary and observed operators. In tab
 
 ### Docker container management
 - **Gluetun network containers (auto-managed)** — running containers using `network_mode: service:gluetun` are detected and recreated automatically after each switch, including those already stuck in a dead namespace (left over from a previously failed switch). Intentionally stopped containers stay stopped. Containers in a **different Compose stack** from Gluetun are also handled if their directory is accessible from Companion or if their `com.docker.compose` labels are present. Orphan detection is limited to containers referencing a **known former Gluetun** (ID history kept in the database) — Companion never touches dependents of another VPN or an unrelated stack
-- **Containers to restart after switch** — only for containers routing through Gluetun's HTTP/SOCKS5 proxy; ordered list (drag & drop)
+- **Containers to restart after switch** — ordered list (drag & drop), applied to manual and automatic switches, pools and failover; containers sharing Gluetun's network namespace are detected, recreated and verified automatically without duplicates
 - **Pause during benchmark** — list of containers (torrent, Usenet…) stopped before the benchmark starts and automatically restarted when it ends, even on error
 - **Automatic Docker image updates** *(option)* — at switch time, Companion can update images before restarting containers: Gluetun itself, auto-managed network containers, post-switch containers and benchmark-paused containers; togglable per container from Settings
 
@@ -483,7 +483,11 @@ Enable via **Settings → Measure → Sidecar Mode → toggle off**.
 
 ### Containers to restart after switch
 
-In **Settings → Decide → Containers to restart after switch**: ordered list of containers recreated after each VPN switch. In Compose mode, Companion uses `docker compose up -d --force-recreate`; in Unraid/DockerMan mode, it recreates containers through the Docker SDK so they rejoin the current Gluetun network namespace. Drag & drop to reorder. Useful for `qbittorrent`, `radarr`, `sonarr`, or any service with `network_mode: service:gluetun`.
+In **Settings → Decide → Containers to restart after switch**: ordered list of containers recreated after every VPN switch, whatever its trigger. In Compose mode, Companion uses `docker compose up -d --force-recreate`; in Unraid/DockerMan mode, it recreates containers through the Docker SDK. Services using `network_mode: service:gluetun` are detected separately, reattached to the new namespace ID and verified; a Docker event also repairs this attachment after an external Gluetun recreation. Drag & drop to reorder.
+
+The **active server** shown on the dashboard and returned by the API is resolved from the tunnel endpoint actually selected by Gluetun and its provider catalogue. `SERVER_*` variables remain selection filters, but a candidate list is no longer presented as the connected server. Changes observed outside Companion are added to switch history.
+
+After every successful benchmark, Companion computes and stores the best server for the active profile even when automatic switching is disabled. End-of-benchmark notifications and history therefore no longer leave “Best server” empty in measure-only mode.
 
 ### Containers to pause during benchmark
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ L'encart **Statut VPN** affiche l'intermédiaire et les opérateurs observés. D
 
 ### Gestion des containers Docker
 - **Containers réseau Gluetun (auto-gérés)** — les containers en cours d'exécution avec `network_mode: service:gluetun` sont détectés et recréés automatiquement après chaque bascule, y compris ceux déjà dans un namespace mort (suite à une bascule précédente ratée). Les containers volontairement stoppés restent stoppés. Les containers dans une **stack Compose différente** de Gluetun sont également gérés si leur répertoire est accessible depuis Companion ou si leurs labels `com.docker.compose` sont présents. La détection d'orphelins est limitée aux containers référençant un **ancien Gluetun connu** (historique d'IDs en base) — Companion ne touche jamais aux dépendants d'un autre VPN ou d'une stack étrangère
-- **Containers à redémarrer après bascule** — uniquement pour les containers utilisant le proxy HTTP/SOCKS5 de Gluetun ; liste ordonnée (glisser-déposer)
+- **Containers à redémarrer après bascule** — liste ordonnée (glisser-déposer), appliquée aux bascules manuelles, automatiques, aux pools et au failover ; les containers partageant directement le namespace réseau de Gluetun sont détectés, recréés et vérifiés automatiquement sans doublon
 - **Pause pendant le benchmark** — liste de containers (torrents, Usenet…) stoppés avant le début du benchmark et relancés automatiquement à la fin, même en cas d'erreur
 - **Mise à jour automatique des images Docker** *(option)* — au moment de la bascule, Companion peut mettre à jour les images avant de relancer les containers : Gluetun lui-même, les containers réseau auto-gérés, les containers à redémarrer après bascule et les containers en pause pendant le benchmark ; activable individuellement par container depuis les Paramètres
 
@@ -482,7 +482,11 @@ Activer via **Paramètres → Mesurer → Mode Sidecar → désactiver**.
 
 ### Containers à redémarrer après bascule
 
-Dans **Paramètres → Décider → Containers à redémarrer après bascule** : liste ordonnée de containers recréés après chaque bascule VPN. En mode Compose, Companion utilise `docker compose up -d --force-recreate` ; en mode Unraid/DockerMan, il recrée les containers via le Docker SDK pour les rattacher au namespace réseau Gluetun courant. Drag & drop pour réordonner. Utile pour `qbittorrent`, `radarr`, `sonarr`, ou tout service avec `network_mode: service:gluetun`.
+Dans **Paramètres → Décider → Containers à redémarrer après bascule** : liste ordonnée de containers recréés après chaque bascule VPN, quel que soit son déclencheur. En mode Compose, Companion utilise `docker compose up -d --force-recreate` ; en mode Unraid/DockerMan, il recrée les containers via le Docker SDK. Les services utilisant `network_mode: service:gluetun` sont détectés séparément, rattachés au nouvel identifiant de namespace puis vérifiés ; un événement Docker répare également ce rattachement après une recréation externe de Gluetun. Drag & drop pour réordonner.
+
+Le **serveur actif** affiché sur le tableau de bord et dans l’API est résolu depuis l’adresse du tunnel réellement sélectionnée par Gluetun et son catalogue de fournisseurs. Les variables `SERVER_*` restent affichées comme filtres de sélection, mais une liste de candidats n’est plus présentée comme s’il s’agissait du serveur connecté. Les changements réellement observés hors Companion sont ajoutés à l’historique des bascules.
+
+À la fin de chaque benchmark réussi, Companion calcule et conserve le meilleur serveur du profil actif, même lorsque la bascule automatique est désactivée. La notification de fin et l’historique ne laissent donc plus « Meilleur serveur » vide en mode mesure seule.
 
 ### Containers à stopper pendant le benchmark
 

--- a/app/api.py
+++ b/app/api.py
@@ -51,7 +51,7 @@ def _api_auth(f):
 @_api_auth
 def status():
     """Current VPN status, active server, benchmark state, next scheduled run."""
-    from .gluetun import get_current_filters, format_filters, get_vpn_status
+    from .gluetun import get_active_server, get_current_filters, format_filters, get_vpn_status
     from .scheduler import get_next_run
     from .dns_path import get_dns_path
 
@@ -70,9 +70,7 @@ def status():
         get_setting('ui_lang', 'fr'),
     )
 
-    active_server = None
-    if filters:
-        active_server = next(iter(filters.values()), None)
+    active_server = get_active_server(current_app.config['GLUETUN_CONTAINER'])
 
     try:
         benchmark_log = json.loads(get_setting('benchmark_log_lines', '[]') or '[]')
@@ -114,10 +112,9 @@ def status():
 def servers():
     """List all configured servers with aggregated stats."""
     from .database import compute_confidence_all, get_stability_all
-    from .gluetun import get_current_filters
+    from .gluetun import get_active_server
 
-    filters = get_current_filters(current_app.config['GLUETUN_CONTAINER'])
-    active_name = next(iter(filters.values()), '').split(',')[0].strip() if filters else ''
+    active_name = get_active_server(current_app.config['GLUETUN_CONTAINER']) or ''
 
     conf_map  = compute_confidence_all()
     stab_map  = get_stability_all()

--- a/app/database.py
+++ b/app/database.py
@@ -547,6 +547,47 @@ def init_db(db_path: str):
                     ('sidecar_image', sidecar_image),
                 )
 
+        # Repair history produced by older versions: the continuous-observation
+        # watchdog inserted a cycle before discovering that its scope was empty,
+        # and measure-only cycles left best_server NULL when auto-switch was off.
+        history_repaired = db.execute(
+            "SELECT value FROM settings WHERE key='benchmark_history_repaired_v1'"
+        ).fetchone()
+        if not history_repaired:
+            db.execute('DELETE FROM benchmark_cycles WHERE finished_at IS NULL')
+            cycles = db.execute(
+                '''SELECT id, started_at, finished_at FROM benchmark_cycles
+                   WHERE finished_at IS NOT NULL
+                     AND (best_server IS NULL OR TRIM(best_server) = '')'''
+            ).fetchall()
+            filter_vars = {
+                'name': 'SERVER_NAMES', 'country': 'SERVER_COUNTRIES',
+                'region': 'SERVER_REGIONS', 'city': 'SERVER_CITIES',
+                'hostname': 'SERVER_HOSTNAMES',
+            }
+            for cycle in cycles:
+                best = db.execute(
+                    '''SELECT st.server_name, s.filter_type
+                       FROM speed_tests st
+                       LEFT JOIN servers s ON s.name = st.server_name
+                       WHERE st.success = 1
+                         AND st.tested_at BETWEEN ? AND ?
+                         AND st.test_method != 'proxy_qc'
+                       ORDER BY st.download_mbps DESC NULLS LAST, st.id DESC
+                       LIMIT 1''',
+                    (cycle['started_at'], cycle['finished_at']),
+                ).fetchone()
+                if best:
+                    prefix = filter_vars.get(best['filter_type'] or 'name', 'SERVER_NAMES')
+                    db.execute(
+                        'UPDATE benchmark_cycles SET best_server=? WHERE id=?',
+                        (f"{prefix}={best['server_name']}", cycle['id']),
+                    )
+            db.execute(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES "
+                "('benchmark_history_repaired_v1', '1')"
+            )
+
 
 @contextmanager
 def get_db():

--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -12,7 +12,9 @@ Network architecture (no shared Docker network required)
 """
 
 import json
+import ipaddress
 import os
+import re
 import subprocess
 import threading
 import time
@@ -27,6 +29,8 @@ from .database import get_setting
 logger = logging.getLogger(__name__)
 
 _PROBE_URL = 'https://www.cloudflare.com/cdn-cgi/trace'
+
+_active_server_cache: dict[str, tuple[str, str]] = {}
 
 # Mapping: short label → Gluetun environment variable name
 FILTER_VARS: dict[str, str] = {
@@ -217,6 +221,83 @@ def format_filters(filters: dict[str, str]) -> str:
     for value in filters.values():
         labels.extend(part.strip() for part in str(value).split(',') if part.strip())
     return ' · '.join(labels) if labels else '—'
+
+
+def _latest_vpn_endpoint(logs: str) -> str | None:
+    """Extract the latest VPN endpoint address reported by Gluetun."""
+    patterns = (
+        r'\[wireguard\]\s+Connecting to\s+(\[[0-9a-fA-F:]+\]|[0-9.]+):\d+',
+        r'\[openvpn\].*?remote[^\n]*?(?:\[AF_INET6?\])?\s*'
+        r'(\[[0-9a-fA-F:]+\]|[0-9a-fA-F:.]+):\d+',
+    )
+    matches: list[tuple[int, str]] = []
+    for pattern in patterns:
+        for match in re.finditer(pattern, logs, flags=re.IGNORECASE):
+            raw = match.group(1).strip('[]')
+            try:
+                matches.append((match.start(), str(ipaddress.ip_address(raw))))
+            except ValueError:
+                continue
+    return max(matches, default=(0, ''))[1] or None
+
+
+def get_active_server(container_name: str) -> str | None:
+    """Return the server Gluetun is really connected to.
+
+    ``SERVER_NAMES`` and the other ``SERVER_*`` variables are selection
+    filters.  They may contain several candidates and therefore cannot be
+    presented as the active server.  Gluetun logs the selected VPN endpoint;
+    this function maps that address through its live provider catalogue.
+
+    If the endpoint cannot be resolved, a single configured filter value is a
+    safe fallback.  With several candidates, the last observed real server is
+    preferred instead of displaying the whole candidate list.
+    """
+    try:
+        container = docker.from_env().containers.get(container_name)
+        container.reload()
+        container_id = container.id
+        logs = container.logs(tail=800).decode('utf-8', errors='replace')
+        endpoint = _latest_vpn_endpoint(logs)
+
+        cached = _active_server_cache.get(container_id)
+        if endpoint and cached and cached[0] == endpoint:
+            return cached[1]
+
+        env = _container_env(container_name)
+        provider = (env.get('VPN_SERVICE_PROVIDER') or '').strip().lower()
+        if endpoint and provider and '/' not in provider and '..' not in provider:
+            result = container.exec_run(
+                ['cat', f'/gluetun/servers/{provider}.json'], demux=False
+            )
+            if result.exit_code == 0:
+                catalogue = json.loads(result.output.decode('utf-8', errors='replace'))
+                for server in catalogue.get('servers', []):
+                    if endpoint in (server.get('ips') or []):
+                        name = (server.get('server_name') or '').strip()
+                        if name:
+                            _active_server_cache.clear()
+                            _active_server_cache[container_id] = (endpoint, name)
+                            return name
+    except Exception as exc:
+        logger.debug('get_active_server endpoint lookup failed: %s', exc)
+
+    filters = get_current_filters(container_name)
+    candidates = [
+        item.strip()
+        for value in filters.values()
+        for item in str(value).split(',')
+        if item.strip()
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    try:
+        observed = get_setting('last_observed_active_server', '').strip()
+        if observed and (not candidates or observed in candidates):
+            return observed
+    except Exception:
+        pass
+    return None
 
 
 def _managed_env_pairs(
@@ -818,7 +899,14 @@ def restart_network_dependents(
         except Exception as exc:
             logger.warning('restart_network_dependents (detect): %s', exc)
 
-    # Restart each container
+    try:
+        current_gluetun_id = docker.from_env().containers.get(container_name).id
+    except Exception:
+        current_gluetun_id = ''
+
+    # Restart each container and verify that Docker resolved the current
+    # Gluetun namespace, rather than accepting a successful Compose exit code
+    # while the dependent still references the previous container ID.
     for name in names_to_restart:
         logger.info('Recreating network-dependent container: %s', name)
         try:
@@ -832,11 +920,68 @@ def restart_network_dependents(
                 unraid.sdk_recreate(name, network_mode=f'container:{container_name}')
             else:
                 _compose_recreate(name, compose_dir, compose_project)
-            restarted.append(name)
+            attached = False
+            for attempt in range(2):
+                try:
+                    dependent = docker.from_env().containers.get(name)
+                    dependent.reload()
+                    mode = dependent.attrs.get('HostConfig', {}).get('NetworkMode', '')
+                    attached = mode in {
+                        f'container:{container_name}',
+                        f'container:{current_gluetun_id}',
+                    }
+                except Exception as inspect_exc:
+                    logger.warning('Cannot verify network namespace for %s: %s', name, inspect_exc)
+                if attached:
+                    break
+                if attempt == 0:
+                    logger.warning(
+                        '%s is still not attached to current Gluetun; retrying recreate', name
+                    )
+                    _compose_recreate(name, compose_dir, compose_project)
+                    time.sleep(1)
+            if attached:
+                restarted.append(name)
+            else:
+                logger.error(
+                    'Network-dependent %s could not be attached to current Gluetun %s',
+                    name, current_gluetun_id[:12] or '?',
+                )
         except Exception as exc:
             logger.warning('Failed to recreate %s: %s', name, exc)
 
     return restarted, updated_imgs
+
+
+def pull_gluetun_before_switch(container_name: str) -> list[str]:
+    """Honor the global Gluetun image-update option for production switches."""
+    if get_setting('pull_gluetun', '0') != '1':
+        return []
+    ok, updated, image = pull_image(container_name)
+    logger.info(
+        'Pre-switch Gluetun pull: %s — %s', image,
+        'updated' if updated else 'up to date' if ok else 'failed',
+    )
+    return [image] if updated else []
+
+
+def restart_configured_post_switch_containers(
+    compose_dir: str = '',
+    compose_project: str = '',
+    already_restarted: set[str] | None = None,
+    exclude: set[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Apply the configured post-switch list consistently on every switch."""
+    try:
+        names = json.loads(get_setting('post_switch_containers', '[]') or '[]')
+        pull_set = set(json.loads(get_setting('pull_post_switch_containers', '[]') or '[]'))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        logger.warning('Invalid post-switch container settings; skipping configured restarts')
+        return [], []
+    skipped = set(already_restarted or set()) | set(exclude or set())
+    return restart_containers_in_order(
+        names, compose_dir, compose_project, exclude=skipped, pull_set=pull_set,
+    )
 
 
 def stop_containers(container_names: list[str]) -> list[str]:

--- a/app/rotation_pools.py
+++ b/app/rotation_pools.py
@@ -326,9 +326,10 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
         set_pool_rotation_state, set_pool_last_error,
     )
     from .gluetun import (
-        switch_server, wait_for_vpn, get_public_ips, get_current_filters,
+        switch_server, wait_for_vpn, get_public_ips, get_active_server,
         list_network_dependents, list_network_dependents_for_recreate,
-        restart_network_dependents,
+        restart_network_dependents, pull_gluetun_before_switch,
+        restart_configured_post_switch_containers,
     )
     from .crypto import decrypt as crypto_decrypt, is_encrypted as is_enc
     from .wg_providers import WG_PROVIDERS
@@ -413,8 +414,7 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
             }
 
     # ── Snapshot current server + IPs + speed before switching ──────────────
-    _cur_filters  = get_current_filters(container)
-    from_server   = list(_cur_filters.values())[0].split(',')[0].strip() if _cur_filters else None
+    from_server   = get_active_server(container)
     pre_deps      = list_network_dependents_for_recreate(container)
 
     # Capture the outgoing VPN provider so port-forward rules can follow a
@@ -446,6 +446,7 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
     set_setting('benchmark_current_server', f'pool:{pool_id}')
 
     # ── Switch Gluetun ────────────────────────────────────────────────────
+    pull_gluetun_before_switch(container)
     ok, err = switch_server(
         filter_value=server['name'],
         filter_type=server['filter_type'],
@@ -475,6 +476,14 @@ def do_pool_rotation(pool_id: int, app, manual: bool = False) -> dict:
     restarted, _ = restart_network_dependents(
         container, compose_dir, project, explicit_list=pre_deps,
     )
+    post_restarted, _ = restart_configured_post_switch_containers(
+        compose_dir, project, already_restarted=set(restarted),
+    )
+    if post_restarted:
+        logger.info(
+            'Pool rotation [%d]: configured post-switch containers restarted: %s',
+            pool_id, ', '.join(post_restarted),
+        )
     if vpn_up:
         logger.info(
             'Pool rotation [%d]: VPN up in %.0fs; recreated %d network dependent(s): %s',

--- a/app/routes.py
+++ b/app/routes.py
@@ -31,7 +31,7 @@ from .crypto import encrypt as crypto_encrypt, decrypt as crypto_decrypt, mask a
 from .profiles import PROFILES, score_servers as _score_servers, score_servers_detail as _score_servers_detail
 from .gluetun import (
     FILTER_VARS, FILTER_LABELS,
-    get_current_filters, format_filters,
+    get_current_filters, get_active_server, format_filters,
     get_public_ip, get_public_ips, get_vpn_status, switch_server,
     apply_dns_filtering,
     wait_for_vpn, restart_network_dependents,
@@ -482,9 +482,9 @@ def dashboard():
 
     vpn_status        = get_vpn_status(proxy_host, proxy_port, px_user, px_pass)
     public_ip         = get_public_ip(proxy_host, proxy_port, px_user, px_pass) if vpn_status == 'running' else None
-    current_filters   = get_current_filters(container)
-    current_server    = format_filters(current_filters)
-    active_server_name = next(iter(current_filters.values()), '').split(',')[0].strip() if current_filters else ''
+    current_filters    = get_current_filters(container)
+    active_server_name = get_active_server(container) or ''
+    current_server     = active_server_name or format_filters(current_filters)
     benchmark_running = get_setting('benchmark_running', '0') == '1'
 
     _ALLOWED_LIMITS = {10, 20, 50}
@@ -888,8 +888,7 @@ def servers():
     # Current active server — read from Gluetun (best-effort, empty string on failure)
     try:
         _container = current_app.config['GLUETUN_CONTAINER']
-        _filters   = get_current_filters(_container)
-        active_server = next(iter(_filters.values())).split(',')[0].strip() if _filters else ''
+        active_server = get_active_server(_container) or ''
     except Exception:
         active_server = ''
 
@@ -1223,7 +1222,7 @@ def manual_switch(server_id):
     wait_secs   = int(get_setting('connection_wait_seconds', '45'))
     lang        = get_setting('ui_lang', 'fr')
 
-    from_label = format_filters(get_current_filters(container))
+    from_label = get_active_server(container) or format_filters(get_current_filters(container))
     from_provider = get_gluetun_provider(container)
 
     # Capture the old server's IP before switching
@@ -1268,7 +1267,12 @@ def manual_switch(server_id):
     # causing "recreated 0 network dependent(s)" even though qBittorrent /
     # Prowlarr / MeTube are up but connected to a dead namespace.
     from .gluetun import list_network_dependents_for_recreate as _list_deps
+    from .gluetun import (
+        pull_gluetun_before_switch as _pull_gluetun,
+        restart_configured_post_switch_containers as _restart_post_switch,
+    )
     pre_switch_deps = _list_deps(container)
+    pull_updated_images = _pull_gluetun(container)
 
     ok, err = switch_server(
         row['name'], row['filter_type'],
@@ -1318,6 +1322,14 @@ def manual_switch(server_id):
                         'Manual switch: %s is not running after %.0fs — '
                         'skipping network-dependent recreate',
                         container, elapsed,
+                    )
+                post_restarted, post_updated = _restart_post_switch(
+                    compose_dir, project, already_restarted=set(restarted),
+                )
+                if post_restarted:
+                    logger.info(
+                        'Manual switch: configured post-switch containers restarted: %s',
+                        ', '.join(post_restarted),
                     )
                 pf_result = apply_current_provider_port_forwards(
                     container, reason='manual_switch',
@@ -1371,6 +1383,7 @@ def manual_switch(server_id):
                         mention=get_setting('notify_mention', '').strip() or None,
                         mention_level=get_setting('notify_mention_level', 'critical'),
                         alert_type='manual_switch',
+                        updated_images=(pull_updated_images + post_updated) or None,
                     )
 
         threading.Thread(target=_bg_restart, daemon=True, name='manual-switch-net').start()
@@ -2452,12 +2465,11 @@ def settings():
         'map_points': [],
     }
     try:
-        _cur_filters = get_current_filters(current_app.config['GLUETUN_CONTAINER'])
-        settings_sidebar['active_server'] = format_filters(_cur_filters) if _cur_filters else ''
-        settings_sidebar['active_server_name'] = (
-            next(iter(_cur_filters.values()), '').split(',')[0].strip()
-            if _cur_filters else ''
-        )
+        _container = current_app.config['GLUETUN_CONTAINER']
+        _cur_filters = get_current_filters(_container)
+        _active = get_active_server(_container) or ''
+        settings_sidebar['active_server'] = _active or (format_filters(_cur_filters) if _cur_filters else '')
+        settings_sidebar['active_server_name'] = _active
     except Exception:
         settings_sidebar['active_server'] = ''
         settings_sidebar['active_server_name'] = ''
@@ -2812,8 +2824,7 @@ def metrics():
     # ── Active server (best-effort) ────────────────────────────────────────
     active_server = ''
     try:
-        _filters = get_current_filters(current_app.config['GLUETUN_CONTAINER'])
-        active_server = next(iter(_filters.values())).split(',')[0].strip() if _filters else ''
+        active_server = get_active_server(current_app.config['GLUETUN_CONTAINER']) or ''
     except Exception:
         pass
 
@@ -3124,8 +3135,7 @@ def api_trackers_check():
         except (TypeError, ValueError):
             ids = None
     try:
-        filters = get_current_filters(current_app.config['GLUETUN_CONTAINER'])
-        server_name = next(iter(filters.values()), '') if filters else ''
+        server_name = get_active_server(current_app.config['GLUETUN_CONTAINER']) or ''
     except Exception:
         server_name = ''
     result = check_enabled_trackers(ids, server_name=server_name)
@@ -3832,7 +3842,7 @@ def api_status():
     return jsonify({
         'vpn_status':             get_vpn_status(cfg['GLUETUN_HOST'], cfg['GLUETUN_PROXY_PORT'], px_user, px_pass),
         'public_ip':              get_public_ip(cfg['GLUETUN_HOST'], cfg['GLUETUN_PROXY_PORT'], px_user, px_pass),
-        'current_server':         format_filters(get_current_filters(cfg['GLUETUN_CONTAINER'])),
+        'current_server':         get_active_server(cfg['GLUETUN_CONTAINER']) or format_filters(get_current_filters(cfg['GLUETUN_CONTAINER'])),
         'benchmark_running':       get_setting('benchmark_running', '0') == '1',
         'benchmark_stop_requested':get_setting('benchmark_stop_requested', '0') == '1',
         'current_server_testing':  get_setting('benchmark_current_server', ''),

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -160,6 +160,42 @@ def _weighted_score(
     return base * confidence_factor * effective_stab
 
 
+def _best_result_for_active_profile(results: list[dict]) -> tuple[dict | None, dict[str, float]]:
+    """Rank successful benchmark results even when auto-switch is disabled."""
+    if not results:
+        return None, {}
+    from .database import (
+        compute_confidence_all,
+        get_db,
+        get_docker_event_counts,
+        get_setting,
+    )
+    from .profiles import score_results
+
+    current_pct = float(get_setting('weighted_score_current_pct', '65'))
+    stability_weight = float(get_setting('stability_weight', '30'))
+    retention_days = int(get_setting('db_retention_days', '30'))
+    confidence = compute_confidence_all()
+    reconnects = get_docker_event_counts(days=retention_days)
+    confidence_factors = {'HIGH': 1.0, 'MEDIUM': 0.95, 'LOW': 0.85}
+    with get_db() as db:
+        weighted = {
+            result['server']: _weighted_score(
+                result['server'], result['dl'], db, current_pct,
+                confidence_factors.get(
+                    confidence.get(result['server'], {}).get('level', 'MEDIUM'), 0.95
+                ),
+                jitter_ms=result.get('jitter_ms'),
+                packet_loss_pct=result.get('packet_loss_pct'),
+                reconnect_count=reconnects.get(result['server'], 0),
+                stability_weight=stability_weight,
+            )
+            for result in results
+        }
+    scores = score_results(results, get_setting('active_profile', 'balanced'), weighted)
+    return max(results, key=lambda item: scores.get(item['server'], 0.0)), scores
+
+
 # ---------------------------------------------------------------------------
 # Per-server test (isolated function so we can run it in a timed thread)
 # ---------------------------------------------------------------------------
@@ -585,16 +621,13 @@ def _quick_check(
     last_dl_mbps is None when no prior result exists.
     """
     from .database import get_db
-    from .gluetun import get_current_filters, get_public_ips
+    from .gluetun import get_active_server, get_public_ips
 
     # ── Identify current server ───────────────────────────────────────────
-    filters = get_current_filters(container)
-    if not filters:
+    server_name = get_active_server(container)
+    if not server_name:
         logger.info('Quick check: cannot read current server from Gluetun — running full benchmark')
         return False, None, None, None
-
-    filter_type = next(iter(filters))
-    server_name = filters[filter_type].split(',')[0].strip()
 
     # ── Last known *proxy* speed ──────────────────────────────────────────
     # We only compare against proxy measurements — sidecar results use a
@@ -1344,9 +1377,6 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
                 '  AND (s.vpn_profile_id IS NULL OR vp.enabled = 1) '
                 'ORDER BY s.name'
             ).fetchall()
-            cycle_id = db.execute(
-                'INSERT INTO benchmark_cycles (started_at) VALUES (CURRENT_TIMESTAMP)'
-            ).lastrowid
 
         if not servers:
             logger.info('No enabled servers — skipping benchmark')
@@ -1444,6 +1474,10 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
             logger.info('No servers left after pre-filters — skipping benchmark')
             _progress_log('Aucun serveur restant dans le perimetre')
             return 0
+        with get_db() as db:
+            cycle_id = db.execute(
+                'INSERT INTO benchmark_cycles (started_at) VALUES (CURRENT_TIMESTAMP)'
+            ).lastrowid
         set_setting('benchmark_total_servers', str(len(servers)))
         set_setting('benchmark_done_servers', '0')
         _progress_log(f'{len(servers)} serveur(s) selectionne(s)')
@@ -1717,6 +1751,26 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
                 )
                 _progress_log('Auto-switch ignore : aucun serveur compatible trackers')
 
+        # A completed benchmark always has a best result.  Previously this was
+        # calculated only inside the auto-switch branch, leaving
+        # benchmark_cycles.best_server and notifications empty whenever the
+        # perfectly valid "measure only" mode (auto_switch=0) was selected.
+        if results:
+            ranked_best, ranked_scores = _best_result_for_active_profile(results)
+            if ranked_best:
+                best_server_name = ranked_best['server']
+                best_server_label = (
+                    f"{FILTER_VARS.get(ranked_best['filter_type'], 'SERVER_NAMES')}="
+                    f"{best_server_name}"
+                )
+                logger.info(
+                    'Benchmark best (profile=%s, auto-switch=%s): %s '
+                    '(%.1f Mbps, score=%.4f)',
+                    get_setting('active_profile', 'balanced'), auto_sw,
+                    best_server_label, ranked_best['dl'],
+                    ranked_scores.get(best_server_name, 0.0),
+                )
+
         if auto_sw and decision_results:
             current_pct      = float(get_setting('weighted_score_current_pct', '65'))
             stability_weight = float(get_setting('stability_weight', '30'))
@@ -1911,7 +1965,8 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
                     if _post_switch:
                         _restarted2, ps_updated = restart_containers_in_order(
                             _post_switch, compose_dir, project,
-                            exclude=pause_exclude, pull_set=pull_post_switch_set,
+                            exclude=(pause_exclude | set(restarted)),
+                            pull_set=pull_post_switch_set,
                         )
                         updated_images.extend(ps_updated)
                         logger.info(
@@ -2729,15 +2784,13 @@ def _run_emergency_failover(app, health_status: str) -> bool:
     global _failover_failed_servers
     from .database import get_setting, set_setting
     from .gluetun import (
-        get_current_filters, get_public_ips, list_network_dependents_for_recreate,
-        restart_network_dependents, switch_server, wait_for_vpn,
+        get_active_server, get_public_ips, list_network_dependents_for_recreate,
+        restart_network_dependents, restart_configured_post_switch_containers,
+        pull_gluetun_before_switch, switch_server, wait_for_vpn,
     )
 
     container = app.config['GLUETUN_CONTAINER']
-    filters = get_current_filters(container)
-    current_server = (
-        next(iter(filters.values()), '').split(',')[0].strip() if filters else None
-    )
+    current_server = get_active_server(container)
     if current_server:
         _failover_failed_servers.add(current_server)
     candidate = _select_failover_candidate(current_server, _failover_failed_servers)
@@ -2760,6 +2813,7 @@ def _run_emergency_failover(app, health_status: str) -> bool:
                 wg_profile = None
                 error = f'VPN profile decryption failed: {exc}'
             if not error:
+                pull_gluetun_before_switch(container)
                 switched, switch_error = switch_server(
                     candidate['name'], candidate['filter_type'], container,
                     app.config['COMPOSE_DIR'], app.config.get('COMPOSE_PROJECT', ''),
@@ -2774,9 +2828,13 @@ def _run_emergency_failover(app, health_status: str) -> bool:
                         proxy_user=get_setting('proxy_username', '') or None,
                         proxy_password=get_setting('proxy_password', '') or None,
                     )
-                    restart_network_dependents(
+                    restarted, _ = restart_network_dependents(
                         container, app.config['COMPOSE_DIR'],
                         app.config.get('COMPOSE_PROJECT', ''), explicit_list=dependents,
+                    )
+                    restart_configured_post_switch_containers(
+                        app.config['COMPOSE_DIR'], app.config.get('COMPOSE_PROJECT', ''),
+                        already_restarted=set(restarted),
                     )
                     if ok:
                         _apply_port_forwards_for_current_provider(container, 'emergency_failover')
@@ -2875,6 +2933,94 @@ def _check_gluetun_failover(app) -> None:
                 _failover_failed_servers.clear()
         finally:
             _lock.release()
+
+
+def _check_active_server_history(app) -> None:
+    """Reconcile the real Gluetun endpoint with display state and switch history."""
+    with app.app_context():
+        from .database import get_db, get_setting, set_setting
+        from .gluetun import get_active_server, get_public_ips
+
+        # During a benchmark the production tunnel may move through candidates.
+        # Reconcile only its final state once the cycle has finished.
+        if get_setting('benchmark_running', '0') == '1':
+            return
+        container_name = app.config['GLUETUN_CONTAINER']
+        active = get_active_server(container_name)
+        if not active:
+            return
+        try:
+            import docker
+            container_id = docker.from_env().containers.get(container_name).id
+        except Exception:
+            container_id = ''
+
+        previous = get_setting('last_observed_active_server', '').strip()
+        previous_id = get_setting('last_observed_gluetun_id', '').strip()
+        if not previous:
+            set_setting('last_observed_active_server', active)
+            set_setting('last_observed_gluetun_id', container_id)
+            return
+        if active == previous:
+            if container_id and container_id != previous_id:
+                set_setting('last_observed_gluetun_id', container_id)
+            return
+
+        def _bare(value: str | None) -> str:
+            return (value or '').split('=', 1)[-1].strip()
+
+        # Companion writes its switch row before the async reconnect completes.
+        # Reuse that row instead of creating a duplicate when its target matches.
+        with get_db() as db:
+            recent = db.execute(
+                '''SELECT to_server FROM switches
+                   WHERE success = 1
+                     AND switched_at >= datetime('now', '-10 minutes')
+                   ORDER BY id DESC LIMIT 20'''
+            ).fetchall()
+        already_recorded = any(_bare(row['to_server']) == active for row in recent)
+        if not already_recorded:
+            try:
+                ipv4, ipv6 = get_public_ips(
+                    app.config['GLUETUN_HOST'], app.config['GLUETUN_PROXY_PORT'],
+                    get_setting('proxy_username', '') or None,
+                    get_setting('proxy_password', '') or None,
+                )
+            except Exception:
+                ipv4 = ipv6 = None
+            reason = 'external_recreate' if previous_id and container_id != previous_id else 'vpn_reconnect'
+            _record_switch(
+                from_server=previous, to_server=active, reason=reason, success=True,
+                to_ipv4=ipv4, to_ipv6=ipv6,
+            )
+            logger.info(
+                'Observed real VPN server change: %s -> %s (%s)', previous, active, reason
+            )
+        set_setting('last_observed_active_server', active)
+        set_setting('last_observed_gluetun_id', container_id)
+
+
+def _repair_network_after_gluetun_start(app, container_name: str) -> None:
+    """Always reattach stale shared-network containers after any Gluetun start."""
+    time.sleep(3)
+    with app.app_context():
+        from .gluetun import list_orphaned_network_dependents, restart_network_dependents
+        try:
+            orphans = list_orphaned_network_dependents()
+            if not orphans:
+                return
+            restarted, _ = restart_network_dependents(
+                container_name,
+                app.config.get('COMPOSE_DIR', ''),
+                app.config.get('COMPOSE_PROJECT', ''),
+                explicit_list=orphans,
+            )
+            logger.info(
+                'Gluetun start network reconciliation: %d/%d reattached (%s)',
+                len(restarted), len(orphans), ', '.join(restarted) or 'none',
+            )
+        except Exception as exc:
+            logger.warning('Gluetun start network reconciliation failed: %s', exc)
 
 
 def _run_event_triggered_quick_check(app):
@@ -2988,6 +3134,14 @@ def _docker_event_loop(app, container_name: str) -> None:
         try:
             import docker as _docker
             client = _docker.from_env()
+            # Remember the currently live ID before waiting for events.  If an
+            # external updater replaces Gluetun, dependents will still point to
+            # this ID and can be identified reliably after the new start event.
+            try:
+                from .gluetun import record_gluetun_id
+                record_gluetun_id(client.containers.get(container_name).id)
+            except Exception:
+                pass
             logger.info(
                 'Docker event listener: watching container "%s" for restart events',
                 container_name,
@@ -3007,6 +3161,17 @@ def _docker_event_loop(app, container_name: str) -> None:
                     record_gluetun_id(event.get('id', ''))
                 except Exception:
                     pass
+
+                # Network repair is mandatory for every Gluetun start,
+                # including Companion-triggered switches and starts occurring
+                # during benchmarks.  Only the optional quick check is subject
+                # to the suppression/cooldown guards below.
+                threading.Thread(
+                    target=_repair_network_after_gluetun_start,
+                    args=(app, container_name),
+                    daemon=True,
+                    name='gluetun-network-repair',
+                ).start()
 
                 # Ignore restarts triggered by Companion itself (server switch)
                 if is_companion_restart():
@@ -3345,6 +3510,15 @@ def start_scheduler(app):
         misfire_grace_time=20,
         max_instances=1,
     )
+    _scheduler.add_job(
+        _check_active_server_history,
+        trigger=IntervalTrigger(seconds=30),
+        args=[app],
+        id='active_server_history',
+        replace_existing=True,
+        misfire_grace_time=20,
+        max_instances=1,
+    )
     _scheduler.start()
 
     # Docker event listener — watches Gluetun container for unexpected restarts
@@ -3400,7 +3574,7 @@ def trigger_observation_now(app):
 def run_quick_check_now(app):
     """Manual quick benchmark — proxy test of current server only, no VPN switch."""
     from .database import get_db, get_setting, set_setting
-    from .gluetun import get_current_filters, get_public_ips
+    from .gluetun import get_active_server, get_public_ips
 
     with _lock:
         _stop_event.clear()   # reset any leftover stop signal
@@ -3418,13 +3592,10 @@ def run_quick_check_now(app):
             warmup      = 2.0 if get_setting('speedtest_warmup', '1') == '1' else 0.0
             dl_streams  = int(get_setting('speedtest_streams', '4'))
 
-            filters = get_current_filters(container)
-            if not filters:
+            server_name = get_active_server(container)
+            if not server_name:
                 logger.warning('Quick benchmark now: cannot read current server from Gluetun')
                 return
-
-            filter_type = next(iter(filters))
-            server_name = filters[filter_type].split(',')[0].strip()
             set_setting('benchmark_current_server', server_name)
 
             # Fetch previous proxy_qc baseline for comparison in notification

--- a/tests/test_active_server.py
+++ b/tests/test_active_server.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.gluetun import (
+    _active_server_cache,
+    _latest_vpn_endpoint,
+    get_active_server,
+)
+
+
+class ActiveServerTest(unittest.TestCase):
+    def setUp(self):
+        _active_server_cache.clear()
+
+    def test_extracts_latest_wireguard_endpoint(self):
+        logs = (
+            'INFO [wireguard] Connecting to 1.2.3.4:51820\n'
+            'INFO [wireguard] Connecting to 198.54.134.251:1637\n'
+        )
+        self.assertEqual(_latest_vpn_endpoint(logs), '198.54.134.251')
+
+    @patch('app.gluetun.docker.from_env')
+    def test_maps_live_endpoint_to_catalogue_server(self, from_env):
+        container = MagicMock()
+        container.id = 'gluetun-id'
+        container.attrs = {
+            'Config': {
+                'Env': [
+                    'VPN_SERVICE_PROVIDER=airvpn',
+                    'SERVER_NAMES=Chamukuy,Elgafar,Dalim,Bunda',
+                ]
+            }
+        }
+        container.logs.return_value = (
+            b'INFO [wireguard] Connecting to 198.54.134.251:1637\n'
+        )
+        container.exec_run.return_value = SimpleNamespace(
+            exit_code=0,
+            output=json.dumps({
+                'servers': [
+                    {'server_name': 'Bunda', 'ips': ['198.54.134.251']},
+                ]
+            }).encode(),
+        )
+        from_env.return_value.containers.get.return_value = container
+
+        self.assertEqual(get_active_server('gluetun-airvpn'), 'Bunda')
+
+    @patch('app.gluetun.get_setting', return_value='Bunda')
+    @patch('app.gluetun.docker.from_env')
+    def test_never_displays_all_candidates_when_endpoint_is_unknown(self, from_env, _setting):
+        container = MagicMock()
+        container.id = 'gluetun-id'
+        container.attrs = {
+            'Config': {
+                'Env': [
+                    'VPN_SERVICE_PROVIDER=airvpn',
+                    'SERVER_NAMES=Chamukuy,Elgafar,Dalim,Bunda',
+                ]
+            }
+        }
+        container.logs.return_value = b'no endpoint in these logs\n'
+        from_env.return_value.containers.get.return_value = container
+
+        self.assertEqual(get_active_server('gluetun-airvpn'), 'Bunda')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_active_server_history.py
+++ b/tests/test_active_server_history.py
@@ -1,0 +1,47 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+from app import database
+from app.scheduler import _check_active_server_history
+
+
+class ActiveServerHistoryTest(unittest.TestCase):
+    @patch('docker.from_env')
+    @patch('app.gluetun.get_public_ips', return_value=('2.2.2.2', None))
+    @patch('app.gluetun.get_active_server', return_value='NewServer')
+    def test_records_an_observed_external_server_change(
+        self, _active, _ips, docker_from_env,
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            database.init_db(os.path.join(tmp, 'companion.db'))
+            database.set_setting('benchmark_running', '0')
+            database.set_setting('last_observed_active_server', 'OldServer')
+            database.set_setting('last_observed_gluetun_id', 'old-container-id')
+            container = MagicMock()
+            container.id = 'new-container-id'
+            docker_from_env.return_value.containers.get.return_value = container
+            flask_app = Flask(__name__)
+            flask_app.config.update({
+                'GLUETUN_CONTAINER': 'gluetun',
+                'GLUETUN_HOST': 'gluetun',
+                'GLUETUN_PROXY_PORT': 8888,
+            })
+
+            _check_active_server_history(flask_app)
+
+            with database.get_db() as db:
+                row = db.execute(
+                    'SELECT from_server, to_server, reason, success FROM switches'
+                ).fetchone()
+            self.assertEqual(row['from_server'], 'OldServer')
+            self.assertEqual(row['to_server'], 'NewServer')
+            self.assertEqual(row['reason'], 'external_recreate')
+            self.assertEqual(row['success'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_benchmark_best.py
+++ b/tests/test_benchmark_best.py
@@ -1,0 +1,40 @@
+import unittest
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from app.scheduler import _best_result_for_active_profile
+
+
+class BenchmarkBestTest(unittest.TestCase):
+    @patch('app.profiles.score_results')
+    @patch('app.database.get_docker_event_counts', return_value={})
+    @patch('app.database.compute_confidence_all', return_value={})
+    @patch('app.database.get_db')
+    @patch('app.database.get_setting')
+    @patch('app.scheduler._weighted_score')
+    def test_ranks_results_without_requiring_auto_switch(
+        self, weighted_score, get_setting, get_db, _confidence, _events, score_results,
+    ):
+        settings = {
+            'weighted_score_current_pct': '65',
+            'stability_weight': '30',
+            'db_retention_days': '30',
+            'active_profile': 'balanced',
+        }
+        get_setting.side_effect = lambda key, default='': settings.get(key, default)
+        get_db.return_value = nullcontext(MagicMock())
+        weighted_score.side_effect = lambda _name, dl, *_args, **_kwargs: dl
+        score_results.return_value = {'Slow': 0.2, 'Fast': 0.9}
+        results = [
+            {'server': 'Slow', 'filter_type': 'name', 'dl': 100.0},
+            {'server': 'Fast', 'filter_type': 'name', 'dl': 900.0},
+        ]
+
+        best, scores = _best_result_for_active_profile(results)
+
+        self.assertEqual(best['server'], 'Fast')
+        self.assertEqual(scores['Fast'], 0.9)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_benchmark_history_repair.py
+++ b/tests/test_benchmark_history_repair.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import unittest
+
+from app import database
+
+
+class BenchmarkHistoryRepairTest(unittest.TestCase):
+    def test_repairs_empty_best_server_and_removes_unfinished_cycles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'companion.db')
+            database.init_db(path)
+            with database.get_db() as db:
+                db.execute(
+                    "INSERT INTO servers (name, filter_type) VALUES ('Bunda', 'name')"
+                )
+                db.execute(
+                    "INSERT INTO speed_tests "
+                    "(server_name, download_mbps, success, tested_at, test_method) "
+                    "VALUES ('Bunda', 900, 1, '2026-07-14 05:30:00', 'sidecar')"
+                )
+                completed_id = db.execute(
+                    "INSERT INTO benchmark_cycles "
+                    "(started_at, finished_at, servers_tested, best_server) "
+                    "VALUES ('2026-07-14 05:00:00', '2026-07-14 06:00:00', 1, NULL)"
+                ).lastrowid
+                db.execute(
+                    "INSERT INTO benchmark_cycles (started_at) VALUES ('2026-07-14 06:30:00')"
+                )
+                db.execute(
+                    "DELETE FROM settings WHERE key='benchmark_history_repaired_v1'"
+                )
+
+            database.init_db(path)
+
+            with database.get_db() as db:
+                rows = db.execute(
+                    'SELECT id, finished_at, best_server FROM benchmark_cycles ORDER BY id'
+                ).fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]['id'], completed_id)
+            self.assertEqual(rows[0]['best_server'], 'SERVER_NAMES=Bunda')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Résumé

Cette correction fiabilise l’état VPN présenté par Companion, l’historique des bascules, le résultat des benchmarks et le rattachement des conteneurs partageant le réseau de Gluetun.

## Corrections

- Détermine le serveur réellement utilisé à partir de l’adresse du tunnel sélectionnée par Gluetun et de son catalogue fournisseur.
- Distingue désormais le serveur actif des filtres `SERVER_NAMES`, `SERVER_COUNTRIES`, `SERVER_REGIONS`, `SERVER_CITIES` et `SERVER_HOSTNAMES`.
- Empêche l’affichage d’une liste de candidats comme s’il s’agissait du serveur connecté.
- Utilise le serveur réel sur le tableau de bord, la page des serveurs, les paramètres, les contrôles rapides et l’API REST.
- Surveille les changements de serveur réellement observés et ajoute à l’historique les bascules effectuées hors Companion.
- Évite les doublons lorsqu’une bascule a déjà été enregistrée par Companion.
- Calcule et conserve le meilleur serveur après chaque benchmark réussi, même lorsque `auto_switch` est désactivé.
- Renseigne correctement le champ « Meilleur serveur » dans les notifications de fin de benchmark.
- Répare les anciens cycles terminés dont le meilleur serveur était vide.
- Supprime les cycles fantômes créés par l’observation continue lorsqu’aucun serveur ne restait dans le périmètre.
- Capture l’identifiant courant de Gluetun avant toute recréation externe.
- Répare le réseau partagé après chaque démarrage de Gluetun, y compris pendant un benchmark ou lors d’une bascule déclenchée par Companion.
- Vérifie après recréation que chaque conteneur dépendant utilise réellement le nouvel identifiant de namespace réseau.
- Retente une fois la recréation lorsqu’un conteneur reste attaché à l’ancien namespace.
- Applique uniformément les options « Mettre à jour l’image Gluetun avant chaque bascule » et « Containers à redémarrer après bascule » aux bascules manuelles, automatiques, aux pools et au failover.
- Évite de recréer deux fois un conteneur déjà pris en charge comme dépendance réseau.
- Met à jour la documentation française et anglaise.
