### PR TITLE
Optimiser le chargement de la page des serveurs

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -65,6 +65,14 @@ def init_db(db_path: str):
                 test_trigger     TEXT
             );
 
+            -- /servers joins and aggregates this history for every configured
+            -- server.  These indexes also make the "last successful IP"
+            -- lookups ordered by tested_at inexpensive.
+            CREATE INDEX IF NOT EXISTS idx_speed_tests_server_tested
+                ON speed_tests(server_name, tested_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_speed_tests_server_success_tested
+                ON speed_tests(server_name, success, tested_at DESC);
+
             CREATE TABLE IF NOT EXISTS switches (
                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
                 from_server  TEXT,
@@ -142,6 +150,8 @@ def init_db(db_path: str):
 
             CREATE INDEX IF NOT EXISTS idx_catalogue_provider
                 ON gluetun_catalogue(provider);
+            CREATE INDEX IF NOT EXISTS idx_catalogue_name
+                ON gluetun_catalogue(name);
 
             CREATE TABLE IF NOT EXISTS airvpn_new_servers (
                 name          TEXT PRIMARY KEY,
@@ -301,6 +311,8 @@ def init_db(db_path: str):
                 ON tracker_sources(tracker_id);
             CREATE INDEX IF NOT EXISTS idx_tracker_checks_tracker
                 ON tracker_checks(tracker_id);
+            CREATE INDEX IF NOT EXISTS idx_tracker_checks_latest_server
+                ON tracker_checks(tracker_id, server_name, checked_at DESC);
             CREATE INDEX IF NOT EXISTS idx_port_forwards_client
                 ON port_forwards(torrent_client_id);
 

--- a/app/torrent_trackers.py
+++ b/app/torrent_trackers.py
@@ -488,13 +488,16 @@ def tracker_status_for_servers(server_names: list[str] | None = None) -> dict[st
             return {}
 
         params: list = []
-        server_filter = ''
+        latest_server_filter = ''
         if server_names:
             names = [str(n) for n in server_names if n]
             if not names:
                 return {}
             placeholders = ','.join('?' for _ in names)
-            server_filter = f'AND tc.server_name IN ({placeholders})'
+            # Restrict the expensive latest-per-tracker aggregation itself.
+            # Filtering only the outer query still groups the full tracker
+            # history for every server before discarding most of it.
+            latest_server_filter = f'AND server_name IN ({placeholders})'
             params.extend(names)
 
         rows = db.execute(f'''
@@ -506,13 +509,13 @@ def tracker_status_for_servers(server_names: list[str] | None = None) -> dict[st
                     SELECT tracker_id, server_name, MAX(checked_at) AS checked_at
                     FROM tracker_checks
                     WHERE server_name != ''
+                    {latest_server_filter}
                     GROUP BY tracker_id, server_name
                 ) lx
                   ON lx.tracker_id = tc.tracker_id
                  AND lx.server_name = tc.server_name
                  AND lx.checked_at = tc.checked_at
                 WHERE tc.server_name != ''
-                {server_filter}
             )
             SELECT server_name,
                    COUNT(*) AS tested,

--- a/tests/test_database_indexes.py
+++ b/tests/test_database_indexes.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+from app import database
+
+
+class DatabaseIndexesTest(unittest.TestCase):
+    def test_servers_page_history_indexes_are_created(self):
+        previous_db_path = database._db_path
+        try:
+            with TemporaryDirectory() as directory:
+                database.init_db(os.path.join(directory, 'test.db'))
+                with database.get_db() as db:
+                    speed_indexes = {
+                        row['name'] for row in db.execute('PRAGMA index_list(speed_tests)')
+                    }
+                    tracker_indexes = {
+                        row['name'] for row in db.execute('PRAGMA index_list(tracker_checks)')
+                    }
+                    catalogue_indexes = {
+                        row['name'] for row in db.execute('PRAGMA index_list(gluetun_catalogue)')
+                    }
+        finally:
+            database._db_path = previous_db_path
+
+            self.assertTrue({
+                'idx_speed_tests_server_tested',
+                'idx_speed_tests_server_success_tested',
+            }.issubset(speed_indexes))
+            self.assertIn('idx_tracker_checks_latest_server', tracker_indexes)
+            self.assertIn('idx_catalogue_name', catalogue_indexes)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Résumé

- ajoute des index SQLite ciblés pour l’historique des benchmarks, le catalogue et les derniers contrôles de trackers ;
- limite l’agrégation des contrôles BitTorrent aux serveurs affichés dès la sous-requête ;
- couvre la création des nouveaux index par un test dédié.

## Validation

- `python -m compileall -q app sidecar tests`
- `.venv/bin/python -m pytest -q` — 115 tests passés
- vérification du plan SQLite : la recherche de dernière IP utilise `idx_speed_tests_server_success_tested`.