### PR TITLE
Masquer les pays exclus de la liste des serveurs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -759,6 +759,9 @@ def _normalize_catalogue_server_type(mode: str, provider: str, server_type: str,
 @login_required
 def servers():
     from .database import get_hourly_benchmark_stats
+    from .server_eligibility import (
+        available_countries, excluded_server_names, parse_excluded_countries,
+    )
     sort           = request.args.get('sort', 'avg_dl')
     type_filter    = request.args.get('type', '').strip()
     q              = request.args.get('q',    '').strip()
@@ -798,6 +801,23 @@ def servers():
     if airvpn_bw_min > 0:
         where_parts.append('COALESCE(av.bw_max_mbps, 0) >= ?')
         params.append(airvpn_bw_min)
+
+    # Country exclusions are a /servers filter too: excluded servers must not
+    # remain available for manual browsing, sorting, or switching from this
+    # page.  Keep configured_server_count below unfiltered so the UI can tell
+    # the user how many configured servers are currently hidden.
+    _excluded_countries = parse_excluded_countries(
+        get_setting('excluded_countries', '[]')
+    )
+    if _excluded_countries:
+        with get_db() as _eligibility_db:
+            _excluded_server_names = excluded_server_names(
+                _eligibility_db, _excluded_countries
+            )
+        if _excluded_server_names:
+            _placeholders = ','.join('?' for _ in _excluded_server_names)
+            where_parts.append(f's.name NOT IN ({_placeholders})')
+            params.extend(sorted(_excluded_server_names))
 
     having_params: list = []
     if from_date:
@@ -1027,12 +1047,9 @@ def servers():
         new_airvpn_countries = ', '.join(sorted(cc_set))
 
     _all_vpn_profiles = get_vpn_profiles()
-    from .server_eligibility import available_countries, parse_excluded_countries
     with get_db() as _countries_db:
         _excluded_country_options = available_countries(_countries_db)
-    _excluded_countries = sorted(parse_excluded_countries(
-        get_setting('excluded_countries', '[]')
-    ))
+    _excluded_countries = sorted(_excluded_countries)
 
     # Providers the user is allowed to add from the catalogue:
     # union of (configured vpn_profiles providers) + (active Gluetun provider).

--- a/tests/test_server_failover.py
+++ b/tests/test_server_failover.py
@@ -30,6 +30,32 @@ class ServerEligibilityTest(unittest.TestCase):
                     excluded_server_names(db, {'FR', 'GB'}), {'Paris', 'London'}
                 )
 
+    def test_country_resolution_can_filter_configured_servers_for_display(self):
+        with TemporaryDirectory() as directory:
+            database.init_db(os.path.join(directory, 'test.db'))
+            with database.get_db() as db:
+                db.executemany(
+                    'INSERT INTO servers (name) VALUES (?)',
+                    [('London',), ('Amsterdam',), ('Unmapped',)],
+                )
+                db.executemany(
+                    "INSERT INTO gluetun_catalogue (provider, name, country, country_code) "
+                    "VALUES ('airvpn', ?, ?, ?)",
+                    [
+                        ('London', 'United Kingdom', 'GB'),
+                        ('Amsterdam', 'Netherlands', 'NL'),
+                    ],
+                )
+                excluded = excluded_server_names(db, {'GB'})
+                visible = [
+                    row['name'] for row in db.execute(
+                        'SELECT name FROM servers WHERE name NOT IN (?) ORDER BY name',
+                        tuple(excluded),
+                    )
+                ]
+
+            self.assertEqual(visible, ['Amsterdam', 'Unmapped'])
+
     def test_failover_candidate_stays_in_profile_and_excludes_countries(self):
         with TemporaryDirectory() as directory:
             database.init_db(os.path.join(directory, 'test.db'))


### PR DESCRIPTION
## Résumé

- applique les pays exclus directement au filtre de `/servers`, avant le tri et la pagination ;
- conserve le compteur global afin d’indiquer les serveurs configurés mais masqués ;
- ajoute une couverture de la résolution des serveurs visibles.

## Validation

- `python -m compileall -q app sidecar tests`
- `.venv/bin/python -m pytest -q` — 116 tests passés.