### PR TITLE
Évite la double recréation des services après un failover

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -79,6 +79,16 @@ Gluetun must expose its HTTP proxy. Companion also needs Docker socket access â€
 
 ```yaml
 services:
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONTAINERS: 1
+      EVENTS: 1
+      POST: 1
+
   gluetun-companion:
     image: ghcr.io/aerya/gluetun-companion:latest
     container_name: gluetun-companion
@@ -95,7 +105,12 @@ services:
       - GLUETUN_PROXY_PORT=8887
       - GLUETUN_CONTAINER=gluetun
       - COMPOSE_DIR=/compose
+      - DOCKER_HOST=tcp://socket-proxy:2375
+    depends_on:
+      - socket-proxy
 ```
+
+`EVENTS=1` is required to detect Gluetun restarts immediately. The directory mounted at `/compose` must contain the Gluetun stack's Compose file; Companion uses it to recreate services sharing Gluetun's network after a switch.
 
 ```bash
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Gluetun doit exposer son proxy HTTP, et Companion doit pouvoir accéder au socke
 
 ```yaml
 services:
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONTAINERS: 1
+      EVENTS: 1
+      POST: 1
+
   gluetun-companion:
     image: ghcr.io/aerya/gluetun-companion:latest
     container_name: gluetun-companion
@@ -95,7 +105,12 @@ services:
       - GLUETUN_PROXY_PORT=8887
       - GLUETUN_CONTAINER=gluetun
       - COMPOSE_DIR=/compose
+      - DOCKER_HOST=tcp://socket-proxy:2375
+    depends_on:
+      - socket-proxy
 ```
+
+`EVENTS=1` est nécessaire pour détecter immédiatement les redémarrages de Gluetun. Le dossier monté sur `/compose` doit être celui qui contient le fichier Compose de la stack Gluetun ; Companion l'utilise pour recréer les services partageant son réseau après une bascule.
 
 ```bash
 docker compose up -d

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -3162,23 +3162,27 @@ def _docker_event_loop(app, container_name: str) -> None:
                 except Exception:
                     pass
 
-                # Network repair is mandatory for every Gluetun start,
-                # including Companion-triggered switches and starts occurring
-                # during benchmarks.  Only the optional quick check is subject
-                # to the suppression/cooldown guards below.
+                # Companion-triggered switches already recreate the captured
+                # network dependents in their own synchronous switch flow.
+                # Starting the generic repair thread as well races two
+                # ``docker compose up --force-recreate`` calls for the same
+                # service and can leave a temporary ``<id>_<service>``
+                # container behind after a name conflict.
+                if is_companion_restart():
+                    logger.info(
+                        'Docker event: Gluetun start detected — Companion-triggered, ignoring'
+                    )
+                    continue
+
+                # External Gluetun starts do not have a switch flow available
+                # to reattach stale shared-network dependents, so repair them
+                # independently before scheduling the optional quick check.
                 threading.Thread(
                     target=_repair_network_after_gluetun_start,
                     args=(app, container_name),
                     daemon=True,
                     name='gluetun-network-repair',
                 ).start()
-
-                # Ignore restarts triggered by Companion itself (server switch)
-                if is_companion_restart():
-                    logger.info(
-                        'Docker event: Gluetun start detected — Companion-triggered, ignoring'
-                    )
-                    continue
 
                 # Cooldown guard
                 now     = time.time()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       CONTAINERS: 1
+      EVENTS: 1
       IMAGES: 1
       NETWORKS: 1
       VOLUMES: 1
@@ -23,9 +24,9 @@ services:
     ports:
       - 8765:8765
     volumes:
-      - /home/aerya/docker/gluetun-companion:/data
-      - /home/aerya/docker/dockge-enhanced/stacks/airvpn:/compose   # <-- adapter
-      - /home/aerya/docker/gluetun/openvpn:/openvpn
+      - ${COMPANION_DATA_PATH:-./data}:/data
+      - ${GLUETUN_COMPOSE_PATH:-../gluetun}:/compose:rw
+      - ${GLUETUN_OPENVPN_PATH:-../gluetun/openvpn}:/openvpn
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:

--- a/tests/test_docker_event_listener.py
+++ b/tests/test_docker_event_listener.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from app.scheduler import _docker_event_loop
+
+
+class _OneStartEvent:
+    def __iter__(self):
+        yield {'Action': 'start', 'id': 'new-gluetun-id'}
+        raise KeyboardInterrupt
+
+
+class DockerEventListenerTest(TestCase):
+    def _client(self):
+        client = MagicMock()
+        client.containers.get.return_value.id = 'current-gluetun-id'
+        client.events.return_value = _OneStartEvent()
+        return client
+
+    def test_companion_restart_does_not_start_parallel_network_repair(self):
+        client = self._client()
+        with (
+            patch('docker.from_env', return_value=client),
+            patch('app.gluetun.record_gluetun_id'),
+            patch('app.gluetun.is_companion_restart', return_value=True),
+            patch('app.scheduler.threading.Thread') as thread,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                _docker_event_loop(MagicMock(), 'gluetun-airvpn')
+
+        thread.assert_not_called()
+
+    def test_external_restart_starts_network_repair(self):
+        client = self._client()
+        with (
+            patch('docker.from_env', return_value=client),
+            patch('app.gluetun.record_gluetun_id'),
+            patch('app.gluetun.is_companion_restart', return_value=False),
+            patch('app.database.get_setting', return_value='1'),
+            patch('app.scheduler.threading.Thread') as thread,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                _docker_event_loop(MagicMock(), 'gluetun-airvpn')
+
+        thread.assert_called_once()
+        self.assertEqual(thread.call_args.kwargs['name'], 'gluetun-network-repair')


### PR DESCRIPTION
## Résumé

- évite de lancer la réparation réseau générique lors d’un redémarrage de Gluetun déclenché par Companion ;
- empêche deux commandes `docker compose up --force-recreate` concurrentes de recréer le même service ;
- conserve la réparation automatique des dépendants lors des redémarrages externes de Gluetun ;
- ajoute explicitement l’accès aux événements Docker dans le Compose fourni ;
- remplace les chemins personnels du Compose par des chemins paramétrables ;
- complète les démarrages rapides français et anglais avec la configuration du socket-proxy.

## Cause

Lors d’un failover, le flux principal recréait déjà les services partageant le réseau de Gluetun. Le listener d’événements Docker lançait simultanément une seconde réparation réseau, ce qui pouvait provoquer un conflit de nom et laisser un conteneur temporaire en état `Created`.

## Validation

- 118 tests automatisés réussis dans l’image officielle ;
- tests dédiés aux redémarrages Companion et externes ajoutés ;
- `docker compose config` validé ;
- stack AirVPN vérifiée après failover : services opérationnels et healthchecks au vert.
