### PR TITLE
Corriger les bascules Compose et l’arrêt des cycles automatiques

### DIFF
--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -50,6 +50,15 @@ FILTER_LABELS: dict[str, str] = {
 }
 
 
+def _compose_override_path(compose_dir: str) -> str:
+    """Return the override filename Docker Compose will load automatically."""
+    if os.path.exists(os.path.join(compose_dir, 'compose.yaml')):
+        return os.path.join(compose_dir, 'compose.override.yaml')
+    if os.path.exists(os.path.join(compose_dir, 'compose.yml')):
+        return os.path.join(compose_dir, 'compose.override.yml')
+    return os.path.join(compose_dir, 'docker-compose.override.yml')
+
+
 # ---------------------------------------------------------------------------
 # Companion-triggered restart suppression
 # ---------------------------------------------------------------------------
@@ -498,9 +507,9 @@ def switch_server(
     wg_profile: 'dict | None' = None,
 ) -> tuple[bool, str | None]:
     """
-    Write a docker-compose.override.yml that sets the correct Gluetun filter
-    variable to `filter_value` and clears all other filter variables (so they
-    don't conflict with values from the main compose file).
+    Write the override file matching the stack's Compose manifest, set the
+    correct Gluetun filter variable to `filter_value`, and clear all other
+    filter variables so they don't conflict with the main compose file.
 
     If *wg_profile* is provided, it must be a dict with:
         compose_provider : str   — value of VPN_SERVICE_PROVIDER (e.g. "airvpn")
@@ -560,7 +569,7 @@ def switch_server(
         f'    environment:\n'
         f'{env_lines}'
     )
-    override_path = os.path.join(compose_dir, 'docker-compose.override.yml')
+    override_path = _compose_override_path(compose_dir)
     try:
         with open(override_path, 'w') as fh:
             fh.write(override)
@@ -631,7 +640,7 @@ def apply_dns_filtering(
 
     service = _detect_compose_service(container_name)
     project = compose_project or _detect_compose_project(container_name)
-    override_path = os.path.join(compose_dir, 'docker-compose.override.yml')
+    override_path = _compose_override_path(compose_dir)
 
     def _safe(raw: str) -> str:
         return raw.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '').replace('\r', '')

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -568,7 +568,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'set_notif_test_fail':     'Échec',
         'set_docker_title':        'Configuration Docker requise',
         'set_docker_hint':         'Pour que le companion puisse contrôler Gluetun, vérifiez que votre <code>docker-compose.yml</code> du companion contient :',
-        'set_docker_note':         'Le companion écrira un <code>docker-compose.override.yml</code> dans ce dossier pour changer <code>SERVER_NAMES</code> et relancera le service avec <code>docker compose up -d</code>.',
+        'set_docker_note':         'Le companion écrira l’override correspondant au manifeste Compose de ce dossier pour changer <code>SERVER_NAMES</code>, puis relancera le service avec <code>docker compose up -d</code>.',
 
         # ── Flash messages ──
         'flash_account_created':    'Compte créé avec succès.',
@@ -1611,7 +1611,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'set_notif_test_fail':     'Failed',
         'set_docker_title':        'Required Docker configuration',
         'set_docker_hint':         'For the companion to control Gluetun, check that your companion\'s <code>docker-compose.yml</code> contains:',
-        'set_docker_note':         'The companion will write a <code>docker-compose.override.yml</code> in this folder to change <code>SERVER_NAMES</code> and restart the service with <code>docker compose up -d</code>.',
+        'set_docker_note':         'The companion will write the override matching this folder’s Compose manifest to change <code>SERVER_NAMES</code>, then restart the service with <code>docker compose up -d</code>.',
 
         # ── Flash messages ──
         'flash_account_created':    'Account created successfully.',

--- a/app/routes.py
+++ b/app/routes.py
@@ -150,6 +150,19 @@ def _active_auto_pool_count() -> int:
         ).fetchone()['n']
 
 
+def _planning_modes(
+    auto_requested: bool,
+    observation_requested: bool,
+    active_auto_pools: int,
+) -> tuple[bool, bool]:
+    """Resolve the effective automatic-cycle switches saved by the settings form."""
+    auto_enabled = auto_requested and not active_auto_pools
+    observation_enabled = observation_requested and (
+        auto_requested or bool(active_auto_pools)
+    )
+    return auto_enabled, observation_enabled
+
+
 def _standby_benchmark_cycle_for_pools() -> None:
     set_setting('auto_benchmark', '0')
     try:
@@ -1852,7 +1865,12 @@ def settings():
             active_auto_pools = _active_auto_pool_count()
             set_setting('test_interval_hours', request.form.get('interval', '6'))
             auto_bm = bool(request.form.get('auto_benchmark'))
-            set_setting('auto_benchmark', '0' if active_auto_pools else ('1' if auto_bm else '0'))
+            auto_enabled, observation_enabled = _planning_modes(
+                auto_bm,
+                bool(request.form.get('continuous_observation')),
+                active_auto_pools,
+            )
+            set_setting('auto_benchmark', '1' if auto_enabled else '0')
             set_setting('quick_check_mode',    '1' if request.form.get('quick_check_mode') else '0')
             try:
                 qct = float(request.form.get('quick_check_threshold', '15'))
@@ -1881,7 +1899,6 @@ def settings():
                     set_setting(_key, str(max(_min_v, min(_v, _max_v))))
                 except ValueError:
                     set_setting(_key, _default)
-            observation_enabled = bool(request.form.get('continuous_observation'))
             set_setting('continuous_observation', '1' if observation_enabled else '0')
             # If the user just disabled a mode whose cycle is currently running,
             # abort it now so "disabled" halts the current activity instead of
@@ -1889,7 +1906,7 @@ def settings():
             # restores the original server (proxy-fallback revert at cycle end).
             if get_setting('benchmark_running', '0') == '1':
                 _run_mode = get_setting('benchmark_mode', '')
-                _eff_auto_bm = auto_bm and not active_auto_pools
+                _eff_auto_bm = auto_enabled
                 if ((_run_mode == 'observation' and not observation_enabled)
                         or (_run_mode == 'benchmark' and not _eff_auto_bm)):
                     from .scheduler import request_stop
@@ -1913,7 +1930,7 @@ def settings():
                 set_setting('airvpn_bench_max_users', str(max(0, _max_users)))
             except ValueError:
                 pass
-            reschedule(float(request.form.get('interval', '6')), enabled=(auto_bm and not active_auto_pools))
+            reschedule(float(request.form.get('interval', '6')), enabled=auto_enabled)
             if observation_enabled:
                 trigger_observation_now(current_app._get_current_object())
             if active_auto_pools and auto_bm:

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3641,10 +3641,20 @@ document.addEventListener('DOMContentLoaded', loadNetworkContainers);
 
 // ── Auto benchmark toggle ─────────────────────────────────────────────────
 function toggleAutoBenchmark(enabled) {
+  const autoToggle = document.getElementById('auto_benchmark');
+  const observationToggle = document.getElementById('continuous_observation');
+  const automaticCyclesAvailable = enabled || (autoToggle && autoToggle.disabled);
   const group = document.getElementById('interval-group');
   if (group) {
     group.style.opacity       = enabled ? '' : '0.45';
     group.style.pointerEvents = enabled ? '' : 'none';
+  }
+  if (observationToggle) {
+    observationToggle.disabled = !automaticCyclesAvailable;
+    if (!automaticCyclesAvailable) {
+      observationToggle.checked = false;
+      toggleObservation(false);
+    }
   }
 }
 toggleAutoBenchmark(document.getElementById('auto_benchmark').checked && !document.getElementById('auto_benchmark').disabled);

--- a/tests/test_gluetun_override.py
+++ b/tests/test_gluetun_override.py
@@ -3,10 +3,27 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
-from app.gluetun import apply_dns_filtering, switch_server
+from app.gluetun import _compose_override_path, apply_dns_filtering, switch_server
 
 
 class SwitchServerOverrideTest(TestCase):
+    def test_uses_override_matching_compose_yaml(self) -> None:
+        with TemporaryDirectory() as directory:
+            compose_dir = Path(directory)
+            (compose_dir / 'compose.yaml').write_text('services: {}\n')
+
+            self.assertEqual(
+                Path(_compose_override_path(directory)).name,
+                'compose.override.yaml',
+            )
+
+    def test_falls_back_to_legacy_override_name(self) -> None:
+        with TemporaryDirectory() as directory:
+            self.assertEqual(
+                Path(_compose_override_path(directory)).name,
+                'docker-compose.override.yml',
+            )
+
     def test_deduplicates_managed_profile_variables(self) -> None:
         profile = {
             'compose_provider': 'airvpn',

--- a/tests/test_planning_modes.py
+++ b/tests/test_planning_modes.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+
+from app.routes import _planning_modes
+
+
+class PlanningModesTest(TestCase):
+    def test_disabling_planning_also_disables_observation(self) -> None:
+        self.assertEqual(
+            _planning_modes(False, True, 0),
+            (False, False),
+        )
+
+    def test_observation_stays_available_with_planning(self) -> None:
+        self.assertEqual(
+            _planning_modes(True, True, 0),
+            (True, True),
+        )
+
+    def test_rotation_pool_can_keep_observation_available(self) -> None:
+        self.assertEqual(
+            _planning_modes(False, True, 1),
+            (False, True),
+        )


### PR DESCRIPTION
## Problème

Lorsqu’un stack utilise `compose.yaml`, Docker Compose charge automatiquement `compose.override.yaml`. Companion écrivait pourtant systématiquement les changements de serveur dans `docker-compose.override.yml`.

La commande de recréation pouvait ainsi réussir tout en réappliquant un ancien serveur provenant de l’override réellement chargé.

Par ailleurs, l’observation continue pouvait rester active après la désactivation du cycle automatique, malgré l’indication « déclenchement manuel uniquement » affichée dans les paramètres.

## Correction

- sélectionne automatiquement le nom d’override correspondant au manifeste :
  - `compose.yaml` → `compose.override.yaml`
  - `compose.yml` → `compose.override.yml`
  - anciens manifests → `docker-compose.override.yml`
- utilise le même override pour les bascules VPN et les réglages DNS ;
- désactive aussi l’observation continue lorsque le cycle automatique est coupé ;
- arrête le cycle d’observation éventuellement en cours ;
- synchronise immédiatement l’état des options dans l’interface ;
- conserve l’observation disponible lorsqu’un pool de rotation automatique gère
  lui-même la planification ;
- actualise l’aide française et anglaise.

## Validation

- 124 tests unitaires réussis ;
- tests de régression sur les conventions de noms Docker Compose ;
- tests de régression sur les combinaisons planification/observation ;
- vérification de l’écriture dans `compose.override.yaml` avec un stack utilisant
  `compose.yaml`.