### PR TITLE
Ajoute un lien vers AirDash

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -124,4 +124,4 @@ Then open [http://localhost:8765](http://localhost:8765). For the complete Compo
 
 ## Third-party apps
 
-- [Unofficial native AirVPN dashboard for iPhone and iPad](https://github.com/zlimteck/AirDash)
+- [AirDash](https://github.com/zlimteck/AirDash) — an unofficial native AirVPN dashboard for iPhone and iPad.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ Ouvrir ensuite [http://localhost:8765](http://localhost:8765). Pour le Compose c
 
 ## Applications tierces
 
-- [Tableau de bord AirVPN natif non officiel pour iPhone et iPad](https://github.com/zlimteck/AirDash)
+- [AirDash](https://github.com/zlimteck/AirDash) — tableau de bord AirVPN natif et non officiel pour iPhone et iPad.

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -112,6 +112,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      flex-wrap: wrap;
       gap: .9rem;
       padding: 1.2rem 1rem;
       margin-top: 2rem;

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1100,6 +1100,7 @@ document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootst
   <span>Aerya</span>
   <img src="https://github.com/Aerya.png" alt="Avatar Aerya">
   <a href="https://github.com/Aerya/Gluetun-Companion" target="_blank" rel="noreferrer noopener">GitHub</a>
+  <span>{{ 'Projet AirVPN à découvrir :' if lang == 'fr' else 'AirVPN project worth discovering:' }} <a href="https://github.com/zlimteck/AirDash" target="_blank" rel="noreferrer noopener">AirDash ↗</a></span>
   <a href="https://upandclear.org" target="_blank" rel="noreferrer noopener">Blog</a>
   <a href="https://ko-fi.com/upandclear" target="_blank" rel="noreferrer noopener">Ko-fi</a>
   <span>❤️</span>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4351,6 +4351,7 @@ function portForwardSyncQbit(id, btn) {
   <span>Aerya</span>
   <img src="https://github.com/Aerya.png" alt="Avatar Aerya">
   <a href="https://github.com/Aerya/Gluetun-Companion" target="_blank" rel="noreferrer noopener">GitHub</a>
+  <span>{{ 'Projet AirVPN à découvrir :' if lang == 'fr' else 'AirVPN project worth discovering:' }} <a href="https://github.com/zlimteck/AirDash" target="_blank" rel="noreferrer noopener">AirDash ↗</a></span>
   <a href="https://upandclear.org" target="_blank" rel="noreferrer noopener">Blog</a>
   <a href="https://ko-fi.com/upandclear" target="_blank" rel="noreferrer noopener">Ko-fi</a>
   <span>❤️</span>


### PR DESCRIPTION
## Résumé

- reformule la présentation d’AirDash dans les README français et anglais ;
- ajoute un lien bilingue vers AirDash dans les footers du dashboard et des réglages ;
- autorise le retour à la ligne du footer pour préserver l’affichage sur les petites largeurs.

## Validation

- `python -m unittest discover -s tests -v` dans l’image publiée : 124 tests réussis ;
- compilation Jinja de `dashboard.html` et `settings.html` ;
- `git diff --check`.