### PR TITLE
Corriger l’affichage des adresses WireGuard enregistrées

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3822,6 +3822,8 @@ function _wgShowFields(providerKey, vpnType, existingVars) {
              autocomplete="off" placeholder="${placeholder}">
       ${isSet ? '<div class="form-text text-success" style="font-size:.72rem"><i class="bi bi-check-circle-fill me-1"></i>{{ t.set_wg_secret_set }}</div>' : ''}
     `;
+    const input = div.querySelector('input');
+    if (input && !f.secret) input.value = existingVal;
     container.appendChild(div);
   });
 }

--- a/tests/test_settings_template.py
+++ b/tests/test_settings_template.py
@@ -1,0 +1,19 @@
+import unittest
+from pathlib import Path
+
+
+SETTINGS_TEMPLATE = (
+    Path(__file__).resolve().parents[1] / 'app' / 'templates' / 'settings.html'
+)
+
+
+class SettingsTemplateTest(unittest.TestCase):
+    def test_existing_non_secret_vpn_profile_values_are_displayed(self):
+        template = SETTINGS_TEMPLATE.read_text(encoding='utf-8')
+
+        self.assertIn("if (input && !f.secret) input.value = existingVal;", template)
+        self.assertNotIn('value="${existingVal}"', template)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Résumé

- affiche les valeurs existantes des champs non secrets lors de l’édition d’un profil VPN
- conserve le masquage des clés et autres secrets
- affecte la valeur via la propriété DOM afin d’éviter toute interpolation directe dans le HTML
- ajoute un test de non-régression pour le modèle des paramètres

## Validation

- `python -m unittest tests.test_settings_template -v`
- `docker run --rm -v "$PWD":/workspace -w /workspace --entrypoint python ghcr.io/aerya/gluetun-companion:latest -m unittest discover -s tests -v` : 160 tests réussis
- `git diff --check`