### PR TITLE
Corriger la récupération des remplacements Compose abandonnés

### DIFF
--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -775,6 +775,58 @@ def apply_dns_filtering(
 # Dependent-container restart
 # ---------------------------------------------------------------------------
 
+def _cleanup_failed_compose_replacements(
+    client,
+    container_name: str,
+    service: str,
+    project: str,
+) -> list[str]:
+    """Remove abandoned ``Created`` containers from a failed Compose replace.
+
+    Compose temporarily renames the old container while ``--force-recreate``
+    installs its replacement.  If that transaction loses track of the renamed
+    container, it can fail with ``No such container: <id>_<name>`` and leave a
+    different ``<id>_<name>`` replacement in ``Created``.  A later recreate is
+    then blocked until that intermediate is removed.
+
+    Only containers carrying Compose's explicit replacement label for this
+    service and project are eligible.  Volumes are never removed.
+    """
+    removed: list[str] = []
+    try:
+        entries = client.api.containers(all=True, filters={'status': ['created']})
+    except Exception as exc:
+        logger.warning('Cannot inspect failed Compose replacements: %s', exc)
+        return removed
+
+    for entry in entries or []:
+        labels = (entry or {}).get('Labels') or {}
+        if labels.get('com.docker.compose.replace') != container_name:
+            continue
+        if labels.get('com.docker.compose.service') != service:
+            continue
+        if project and labels.get('com.docker.compose.project') != project:
+            continue
+        cid = (entry or {}).get('Id', '')
+        names = [str(n).lstrip('/') for n in ((entry or {}).get('Names') or [])]
+        if not cid or container_name in names:
+            continue
+        label = names[0] if names else cid[:12]
+        try:
+            client.api.remove_container(cid, v=False, force=False)
+            removed.append(label)
+            logger.warning(
+                'Removed abandoned Compose replacement %s for %s; retrying recreate',
+                label, container_name,
+            )
+        except Exception as exc:
+            logger.warning(
+                'Cannot remove abandoned Compose replacement %s for %s: %s',
+                label, container_name, exc,
+            )
+    return removed
+
+
 def _compose_recreate(
     container_name: str,
     compose_dir: str = '',
@@ -861,6 +913,23 @@ def _compose_recreate(
         if result.returncode == 0:
             return   # success
         last_err = (result.stderr or result.stdout or 'unknown error').strip()
+        # Compose can abandon an intermediate replacement in ``Created`` while
+        # reporting a different, already-gone temporary name.  Clean up only a
+        # positively labelled replacement for this service, then retry once.
+        if ('No such container:' in last_err and
+                _cleanup_failed_compose_replacements(
+                    client, container_name, service, project,
+                )):
+            retry = subprocess.run(
+                cmd,
+                cwd=work_dir,
+                capture_output=True,
+                text=True,
+                timeout=90,
+            )
+            if retry.returncode == 0:
+                return
+            last_err = (retry.stderr or retry.stdout or 'unknown error').strip()
         logger.warning(
             'Compose recreate attempt failed for %s (cwd=%s): %s — trying next candidate',
             container_name, work_dir, last_err,

--- a/tests/test_gluetun_dependents.py
+++ b/tests/test_gluetun_dependents.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from app.gluetun import (
+    _compose_recreate,
     _verify_attached,
     list_network_dependents,
     list_orphaned_network_dependents,
@@ -295,6 +296,83 @@ class DependentRecreateBackendTest(unittest.TestCase):
         self.assertEqual(restarted, [])
         self.assertEqual(sdk_recreate.call_count, 2)     # initial + retry
         compose_recreate.assert_not_called()
+
+
+class ComposeReplacementRecoveryTest(unittest.TestCase):
+    @patch('app.gluetun.os.path.isdir', return_value=True)
+    @patch('app.gluetun.subprocess.run')
+    @patch('docker.from_env')
+    def test_created_replacement_is_removed_without_volumes_then_retried(
+        self, from_env, run, _isdir,
+    ):
+        current = MagicMock()
+        current.labels = {
+            'com.docker.compose.service': 'qbittorrentvpn1',
+            'com.docker.compose.project': 'airvpn',
+            'com.docker.compose.project.working_dir': '/compose',
+        }
+        client = MagicMock()
+        client.containers.get.return_value = current
+        client.api.containers.return_value = [{
+            'Id': 'created-id',
+            'Names': ['/7cebe17ebeda_qbittorrentvpn1'],
+            'Labels': {
+                'com.docker.compose.replace': 'qbittorrentvpn1',
+                'com.docker.compose.service': 'qbittorrentvpn1',
+                'com.docker.compose.project': 'airvpn',
+            },
+        }]
+        from_env.return_value = client
+        run.side_effect = [
+            MagicMock(
+                returncode=1,
+                stderr='Error response from daemon: No such container: old_qbittorrentvpn1',
+                stdout='',
+            ),
+            MagicMock(returncode=0, stderr='', stdout=''),
+        ]
+
+        _compose_recreate('qbittorrentvpn1', '/compose', 'airvpn')
+
+        self.assertEqual(run.call_count, 2)
+        client.api.remove_container.assert_called_once_with(
+            'created-id', v=False, force=False,
+        )
+
+    @patch('app.gluetun.os.path.isdir', return_value=True)
+    @patch('app.gluetun.subprocess.run')
+    @patch('docker.from_env')
+    def test_unrelated_created_container_is_never_removed(
+        self, from_env, run, _isdir,
+    ):
+        current = MagicMock()
+        current.labels = {
+            'com.docker.compose.service': 'qbittorrentvpn1',
+            'com.docker.compose.project': 'airvpn',
+            'com.docker.compose.project.working_dir': '/compose',
+        }
+        client = MagicMock()
+        client.containers.get.return_value = current
+        client.api.containers.return_value = [{
+            'Id': 'unrelated-id',
+            'Names': ['/temporary_other_service'],
+            'Labels': {
+                'com.docker.compose.replace': 'other-service',
+                'com.docker.compose.service': 'other-service',
+                'com.docker.compose.project': 'airvpn',
+            },
+        }]
+        from_env.return_value = client
+        run.return_value = MagicMock(
+            returncode=1,
+            stderr='Error response from daemon: No such container: missing',
+            stdout='',
+        )
+
+        with self.assertRaises(RuntimeError):
+            _compose_recreate('qbittorrentvpn1', '/compose', 'airvpn')
+
+        client.api.remove_container.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Résumé

- détecte les conteneurs de remplacement laissés en état `Created` après un échec `No such container`
- limite strictement le nettoyage au même conteneur, service et projet grâce aux labels Compose
- supprime l’intermédiaire sans supprimer ses volumes, puis effectue une seule nouvelle tentative
- laisse intacts les conteneurs temporaires appartenant à d’autres services

## Impact

Une dépendance réseau ne reste plus absente après une transaction `docker compose --force-recreate` interrompue. La récupération est automatique et limitée au remplacement explicitement associé au service en cours.

## Validation

- `177 passed, 4 subtests passed`
- test de récupération d’un remplacement `Created`
- test de non-régression pour un conteneur temporaire sans rapport
- `git diff --check`
