### PR TITLE
Documenter l’accès au Control Server Gluetun

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -117,6 +117,29 @@ services:
 
 `EVENTS=1` is required to detect Gluetun restarts immediately. The directory mounted at `/compose` must contain the Gluetun stack's Compose file; Companion uses it to recreate services sharing Gluetun's network after a switch.
 
+### Gluetun Control Server: access and authentication
+
+Companion reads the VPN state and forwarded port through the [official Gluetun Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). Routes are private by default in recent Gluetun releases: publishing the port is therefore not enough, and authentication must also be configured.
+
+The recommended method with Companion is an API key:
+
+1. Generate a key with `docker run --rm qmcgaw/gluetun genkey`.
+2. Add the port and role to the Gluetun service. The host port may differ when `8000` is already in use:
+
+```yaml
+services:
+  gluetun:
+    ports:
+      - "8043:8000/tcp"
+    environment:
+      - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"apikey","apikey":"YOUR_API_KEY"}
+```
+
+3. In **Companion → Settings → VPN forwarded ports**, enter the URL reachable from the Companion container, for example `http://host.docker.internal:8043`, then enter the same key in **X-API-Key**.
+4. Recreate Gluetun after changing the configuration and confirm Companion displays its state without a `401` or `403` error.
+
+`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE='{"auth":"none"}'` disables authentication, but the Gluetun documentation strongly discourages it. Never expose the Control Server directly to the Internet; if remote access is unavoidable, protect it with TLS and a reverse proxy.
+
 ### WireGuard: Companion-managed configuration
 
 To let Companion benchmark servers and then select and switch automatically to the best one for a natively supported provider (including ProtonVPN), do not mount a `wg0.conf` file at `/gluetun/wireguard/wg0.conf`. Gluetun gives that file and its WireGuard endpoint priority, which conflicts with the `SERVER_*` variables written by Companion. Configure the provider and WireGuard credentials through a VPN profile in Companion instead.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ services:
 
 `EVENTS=1` est nécessaire pour détecter immédiatement les redémarrages de Gluetun. Le dossier monté sur `/compose` doit être celui qui contient le fichier Compose de la stack Gluetun ; Companion l'utilise pour recréer les services partageant son réseau après une bascule.
 
+### Control Server Gluetun : accès et authentification
+
+Companion lit l’état du VPN et le port forwardé avec le [Control Server officiel de Gluetun](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md). Les routes sont privées par défaut dans les versions récentes de Gluetun : publier le port ne suffit donc pas, il faut aussi choisir une authentification.
+
+La méthode recommandée avec Companion est une clé API :
+
+1. Générez une clé avec `docker run --rm qmcgaw/gluetun genkey`.
+2. Ajoutez le port et le rôle au service Gluetun. Le port hôte peut être différent si `8000` est déjà utilisé :
+
+```yaml
+services:
+  gluetun:
+    ports:
+      - "8043:8000/tcp"
+    environment:
+      - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"apikey","apikey":"VOTRE_CLE_API"}
+```
+
+3. Dans **Companion → Paramètres → Ports forwardés VPN**, indiquez l’URL accessible depuis le container Companion, par exemple `http://host.docker.internal:8043`, puis saisissez la même clé dans **X-API-Key**.
+4. Recréez Gluetun après la modification et vérifiez que Companion affiche son état sans erreur `401` ou `403`.
+
+`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE='{"auth":"none"}'` désactive l’authentification, mais la documentation Gluetun le déconseille fortement. N’exposez jamais le Control Server directement sur Internet ; si un accès distant est indispensable, protégez-le avec TLS et un reverse proxy.
+
 ### WireGuard : configuration pilotée par Companion
 
 Pour permettre à Companion de benchmarker les serveurs puis de sélectionner et basculer automatiquement vers le meilleur d'un fournisseur pris en charge nativement (notamment ProtonVPN), ne montez pas de fichier `wg0.conf` dans `/gluetun/wireguard/wg0.conf`. Gluetun donne priorité à ce fichier et à son endpoint WireGuard, ce qui est incompatible avec les variables `SERVER_*` écrites par Companion. Configurez plutôt le fournisseur et les identifiants WireGuard via un profil VPN dans Companion.


### PR DESCRIPTION
## Modifications

- Ajoute une procédure française et anglaise pour rendre le Control Server Gluetun accessible à Companion.
- Explique que les routes Gluetun récentes sont privées par défaut et que publier le port ne suffit pas.
- Recommande une clé API commune à Gluetun et Companion, avec un exemple de port hôte alternatif.
- Indique où saisir l’URL et la clé dans la WebUI, puis comment reconnaître une erreur d’authentification.
- Documente les risques de `auth:none` et renvoie vers la documentation officielle Gluetun.

## Validation

- Exemple Compose analysé comme YAML valide.
- Liens et versions française/anglaise vérifiés.
- `git diff --check` réussi.
