### PR TITLE
Clarifier le Control Server et le port forwarding ProtonVPN

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -138,11 +138,36 @@ services:
 3. In **Companion → Settings → VPN forwarded ports**, enter the URL reachable from the Companion container, for example `http://host.docker.internal:8043`, then enter the same key in **X-API-Key**.
 4. Recreate Gluetun after changing the configuration and confirm Companion displays its state without a `401` or `403` error.
 
-`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE='{"auth":"none"}'` disables authentication, but the Gluetun documentation strongly discourages it. Never expose the Control Server directly to the Internet; if remote access is unavoidable, protect it with TLS and a reverse proxy.
+In `8043:8000`, `8000` is Gluetun's internal port and `8043` is the port published on the host. If your setup requires adding the Control Server to `FIREWALL_INPUT_PORTS`, use `8000`, never `8043`. You may leave the URL field empty when Docker autodetection works; with a remapped port, Portainer or Synology, enter the URL explicitly. It must be reachable **from the Companion container**, not only from the host or your browser.
+
+Quick diagnostics:
+
+```bash
+# From the Docker host — replace 8043 with the selected host port
+curl -i http://127.0.0.1:8043/v1/portforward
+
+# From the Gluetun container — the internal port is always 8000
+docker exec gluetun wget -S -O- http://127.0.0.1:8000/v1/portforward
+```
+
+The expected response is `HTTP/1.1 200 OK` with content such as `{"port":47987,"ports":[47987]}`. A `401` or `403` means the API key is not configured identically in Gluetun and Companion.
+
+On a fully trusted LAN only, the following Compose form disables authentication:
+
+```yaml
+environment:
+  - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"none"}
+```
+
+The Gluetun documentation strongly discourages this option. Never expose the Control Server directly to the Internet; if remote access is unavoidable, protect it with TLS and a reverse proxy.
+
+With ProtonVPN, enable `VPN_PORT_FORWARDING=on` and use a **Gluetun native** rule without a fixed port. Gluetun obtains the dynamic port; Companion reads it and then synchronizes qBittorrent. Do not add this dynamic port to `FIREWALL_VPN_INPUT_PORTS`, `FIREWALL_INPUT_PORTS`, or Docker port mappings.
 
 ### WireGuard: Companion-managed configuration
 
 To let Companion benchmark servers and then select and switch automatically to the best one for a natively supported provider (including ProtonVPN), do not mount a `wg0.conf` file at `/gluetun/wireguard/wg0.conf`. Gluetun gives that file and its WireGuard endpoint priority, which conflicts with the `SERVER_*` variables written by Companion. Configure the provider and WireGuard credentials through a VPN profile in Companion instead.
+
+The main profile **WireGuard private key** is required for Gluetun switches. The **Sidecar private key** is a second identity reserved for benchmark containers: it never replaces the main key.
 
 A `wg0.conf` is still suitable for a fixed custom WireGuard configuration. In this mode, Companion cannot benchmark servers by switching the main Gluetun container or automatically apply the best result. Isolated sidecar benchmarks remain possible with a compatible VPN profile, but Companion refuses managed switches so it cannot apply an override that would stop Gluetun.
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,36 @@ services:
 3. Dans **Companion → Paramètres → Ports forwardés VPN**, indiquez l’URL accessible depuis le container Companion, par exemple `http://host.docker.internal:8043`, puis saisissez la même clé dans **X-API-Key**.
 4. Recréez Gluetun après la modification et vérifiez que Companion affiche son état sans erreur `401` ou `403`.
 
-`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE='{"auth":"none"}'` désactive l’authentification, mais la documentation Gluetun le déconseille fortement. N’exposez jamais le Control Server directement sur Internet ; si un accès distant est indispensable, protégez-le avec TLS et un reverse proxy.
+Dans `8043:8000`, `8000` est le port interne de Gluetun et `8043` le port publié sur l’hôte. Si votre configuration exige d’ajouter le Control Server à `FIREWALL_INPUT_PORTS`, utilisez donc `8000`, jamais `8043`. Vous pouvez laisser le champ URL vide lorsque l’autodétection Docker fonctionne ; avec un port remappé, Portainer ou Synology, renseignez l’URL explicitement. Elle doit être joignable **depuis le container Companion**, pas seulement depuis l’hôte ou votre navigateur.
+
+Diagnostic rapide :
+
+```bash
+# Depuis l’hôte Docker — remplacez 8043 par le port hôte choisi
+curl -i http://127.0.0.1:8043/v1/portforward
+
+# Depuis le container Gluetun — le port interne reste toujours 8000
+docker exec gluetun wget -S -O- http://127.0.0.1:8000/v1/portforward
+```
+
+La réponse attendue est `HTTP/1.1 200 OK` avec un contenu tel que `{"port":47987,"ports":[47987]}`. Un `401` ou `403` indique que la clé API n’est pas configurée de la même façon dans Gluetun et Companion.
+
+Sur un LAN réellement maîtrisé uniquement, la forme Compose suivante désactive l’authentification :
+
+```yaml
+environment:
+  - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"none"}
+```
+
+La documentation Gluetun déconseille fortement cette option. N’exposez jamais le Control Server directement sur Internet ; si un accès distant est indispensable, protégez-le avec TLS et un reverse proxy.
+
+Avec ProtonVPN, activez `VPN_PORT_FORWARDING=on` et utilisez une règle **Natif Gluetun** sans port fixe. Gluetun obtient le port dynamique ; Companion le lit puis synchronise qBittorrent. N’ajoutez pas ce port dynamique à `FIREWALL_VPN_INPUT_PORTS`, `FIREWALL_INPUT_PORTS` ou aux mappings Docker.
 
 ### WireGuard : configuration pilotée par Companion
 
 Pour permettre à Companion de benchmarker les serveurs puis de sélectionner et basculer automatiquement vers le meilleur d'un fournisseur pris en charge nativement (notamment ProtonVPN), ne montez pas de fichier `wg0.conf` dans `/gluetun/wireguard/wg0.conf`. Gluetun donne priorité à ce fichier et à son endpoint WireGuard, ce qui est incompatible avec les variables `SERVER_*` écrites par Companion. Configurez plutôt le fournisseur et les identifiants WireGuard via un profil VPN dans Companion.
+
+La **clé privée WireGuard** du profil principal est obligatoire pour les bascules de Gluetun. La **clé privée Sidecar** est une seconde identité réservée aux containers de benchmark : elle ne remplace jamais la clé principale.
 
 Un `wg0.conf` reste adapté à une configuration WireGuard custom et figée. Dans ce mode, Companion ne peut ni benchmarker les serveurs en basculant le Gluetun principal, ni appliquer automatiquement le meilleur résultat. Des benchmarks isolés par sidecar restent possibles avec un profil VPN compatible, mais Companion refuse toute bascule gérée afin de ne pas appliquer un override qui arrêterait Gluetun.
 

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -56,6 +56,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'start_step1_body':      'Avant d’utiliser les boutons, Companion doit pouvoir parler à Gluetun et à Docker. Vérifiez ces quatre branchements dans vos fichiers Compose :',
         'start_gluetun_compose_title': 'Dans le Compose de Gluetun',
         'start_gluetun_compose_body':  'Ajoutez le proxy HTTP et le Control Server au service Gluetun. Générez d’abord une clé avec docker run --rm qmcgaw/gluetun genkey, puis remplacez VOTRE_CLE_API.',
+        'start_control_port_mapping':  'Dans <code>8043:8000</code>, <code>8043</code> est le port de l’hôte et <code>8000</code> le port interne de Gluetun. Dans Companion, saisissez <code>http://host.docker.internal:8043</code> et la même clé dans <strong>X-API-Key</strong>. Laissez le champ URL vide seulement si l’autodétection fonctionne. Si vous ajoutez ce service à <code>FIREWALL_INPUT_PORTS</code>, utilisez le port interne <code>8000</code>.',
+        'start_control_diagnostic':    'La première commande teste depuis l’hôte ; la seconde depuis Gluetun. Vous devez obtenir HTTP 200 et un port. HTTP 401/403 signifie que la clé API ne correspond pas.',
         'start_proxy_wiki':      'Documentation officielle du proxy HTTP',
         'start_control_wiki':    'Documentation officielle du Control Server',
         'start_companion_compose_title': 'Dans le Compose de Companion',
@@ -1042,7 +1044,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
 
         # ── Per-profile sidecar key ──
         'set_wg_profile_sidecar_title': 'Clé sidecar dédiée (recommandée en mode sidecar)',
-        'set_wg_profile_sidecar_hint':  'Pour un sidecar isolé, créez un deuxième device/peer WireGuard chez le fournisseur et renseignez ses valeurs ici. Chez AirVPN, réexporter le même device redonne logiquement le même triplet PrivateKey/PresharedKey/Address.',
+        'set_wg_profile_sidecar_hint':  'Cette seconde identité sert uniquement aux benchmarks et ne remplace jamais la clé WireGuard principale du profil, obligatoire pour basculer Gluetun. Pour un sidecar isolé, créez un deuxième device/peer WireGuard chez le fournisseur et renseignez ses valeurs ici. Chez AirVPN, réexporter le même device redonne logiquement le même triplet PrivateKey/PresharedKey/Address.',
         'set_wg_profile_sidecar_reuse': 'Réutiliser la configuration WireGuard du profil principal',
         'set_wg_profile_sidecar_reuse_hint': 'Option avancée : autorise le sidecar à utiliser les mêmes identifiants WireGuard que Gluetun principal. Selon le fournisseur, deux tunnels simultanés avec le même peer peuvent couper ou perturber le tunnel principal.',
         'set_wg_profile_sidecar_pk':    'Clé privée sidecar',
@@ -1278,6 +1280,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         'start_step1_body':      'Before using the buttons, Companion must be able to talk to Gluetun and Docker. Check these four connections in your Compose files:',
         'start_gluetun_compose_title': 'In the Gluetun Compose file',
         'start_gluetun_compose_body':  'Add the HTTP proxy and Control Server to the Gluetun service. First generate a key with docker run --rm qmcgaw/gluetun genkey, then replace YOUR_API_KEY.',
+        'start_control_port_mapping':  'In <code>8043:8000</code>, <code>8043</code> is the host port and <code>8000</code> is Gluetun’s internal port. In Companion, enter <code>http://host.docker.internal:8043</code> and the same key in <strong>X-API-Key</strong>. Leave the URL field empty only when autodetection works. If you add this service to <code>FIREWALL_INPUT_PORTS</code>, use the internal port <code>8000</code>.',
+        'start_control_diagnostic':    'The first command tests from the host; the second tests from Gluetun. Expect HTTP 200 and a port. HTTP 401/403 means the API key does not match.',
         'start_proxy_wiki':      'Official HTTP proxy documentation',
         'start_control_wiki':    'Official Control Server documentation',
         'start_companion_compose_title': 'In the Companion Compose file',
@@ -2264,7 +2268,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
 
         # ── Per-profile sidecar key ──
         'set_wg_profile_sidecar_title': 'Dedicated sidecar key (recommended in sidecar mode)',
-        'set_wg_profile_sidecar_hint':  'For an isolated sidecar, create a second WireGuard device/peer at the provider and enter its values here. With AirVPN, exporting the same device again will logically return the same PrivateKey/PresharedKey/Address triplet.',
+        'set_wg_profile_sidecar_hint':  'This second identity is only used for benchmarks and never replaces the main profile WireGuard key, which is required to switch Gluetun. For an isolated sidecar, create a second WireGuard device/peer at the provider and enter its values here. With AirVPN, exporting the same device again will logically return the same PrivateKey/PresharedKey/Address triplet.',
         'set_wg_profile_sidecar_reuse': 'Reuse the main profile WireGuard configuration',
         'set_wg_profile_sidecar_reuse_hint': 'Advanced option: lets the sidecar use the same WireGuard identity as the main Gluetun instance. Depending on the provider, two simultaneous tunnels with the same peer may drop or disturb the main tunnel.',
         'set_wg_profile_sidecar_pk':    'Sidecar private key',

--- a/app/templates/getting_started.html
+++ b/app/templates/getting_started.html
@@ -27,11 +27,15 @@
   gluetun:
     ports:
       - "8888:8888/tcp"
-      - "8000:8000/tcp"
+      - "8043:8000/tcp"
     environment:
       - HTTPPROXY=on
       - HTTPPROXY_LISTENING_ADDRESS=:8888
       - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"apikey","apikey":"{{ 'VOTRE_CLE_API' if lang == 'fr' else 'YOUR_API_KEY' }}"}</code></pre>
+          <p class="small mb-2">{{ t.start_control_port_mapping | safe }}</p>
+          <pre class="small mb-2"><code>curl -i http://127.0.0.1:8043/v1/portforward
+docker exec gluetun wget -S -O- http://127.0.0.1:8000/v1/portforward</code></pre>
+          <p class="small text-muted">{{ t.start_control_diagnostic }}</p>
           <div class="d-flex flex-wrap gap-2">
             <a class="btn btn-sm btn-outline-secondary" href="https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/http-proxy.md" target="_blank" rel="noopener">{{ t.start_proxy_wiki }}</a>
             <a class="btn btn-sm btn-outline-secondary" href="https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md" target="_blank" rel="noopener">{{ t.start_control_wiki }}</a>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -2389,6 +2389,9 @@
           <input name="port_forward_gluetun_api_url" class="form-control form-control-sm font-monospace"
                  value="{{ cfg.port_forward_gluetun_api_url }}" placeholder="http://host.docker.internal:8000">
           <div class="form-text">
+            {{ 'Laissez vide pour l’autodétection Docker. Avec un port hôte remappé, indiquez l’URL joignable depuis Companion, par exemple http://host.docker.internal:8043.' if lang == 'fr' else 'Leave empty for Docker autodetection. With a remapped host port, enter the URL reachable from Companion, for example http://host.docker.internal:8043.' }}
+          </div>
+          <div class="form-text">
             {% if gluetun_native_portforward.ok %}
             {{ 'Port natif détecté' if lang == 'fr' else 'Native port detected' }} :
             <code>{{ gluetun_native_portforward.ports | join(', ') }}</code>

--- a/tests/test_settings_template.py
+++ b/tests/test_settings_template.py
@@ -42,7 +42,15 @@ class SettingsTemplateTest(unittest.TestCase):
         self.assertIn('getting_started_import_active_profile', guide)
         self.assertIn('setup/options/http-proxy.md', guide)
         self.assertIn('setup/advanced/control-server.md', guide)
+        self.assertIn('8043:8000', guide)
+        self.assertIn('/v1/portforward', guide)
         self.assertIn("url_for('main.getting_started')", base)
+
+    def test_control_server_help_covers_custom_host_mapping(self):
+        template = SETTINGS_TEMPLATE.read_text(encoding='utf-8')
+
+        self.assertIn('http://host.docker.internal:8043', template)
+        self.assertIn('autodétection Docker', template)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Résumé

- explique le mapping entre le port interne 8000 de Gluetun et un port hôte personnalisé comme 8043
- précise quand utiliser l’autodétection ou une URL explicitement joignable depuis Companion
- ajoute des commandes de diagnostic et les réponses attendues du Control Server
- documente l’authentification par clé API, l’option LAN sans authentification et les précautions associées
- clarifie le port forwarding natif ProtonVPN et la différence entre clé WireGuard principale et clé Sidecar
- applique ces explications aux README français et anglais ainsi qu’au guide intégré

## Validation

- `python -m unittest discover -s tests` dans l’image officielle : 189 tests réussis
- `git diff --check`
