### PR TITLE
Fix benchmark rotation with sqlite rows

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -167,6 +167,14 @@ def _weighted_score(
     return base * confidence_factor * effective_stab
 
 
+def _build_server_profile_map(servers):
+    """Map server names to VPN profile metadata from sqlite3.Row records."""
+    return {
+        row['name']: (row['vpn_profile_id'], bool(row['vp_rotation_allowed']))
+        for row in servers
+    }
+
+
 def _best_result_for_active_profile(results: list[dict]) -> tuple[dict | None, dict[str, float]]:
     """Rank successful benchmark results even when auto-switch is disabled."""
     if not results:
@@ -1833,10 +1841,7 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
                 )
 
                 # Build lookup helpers: profile id and rotation_allowed flag per server name
-                _srv_profile_map = {
-                    row['name']: (row['vpn_profile_id'], bool(row.get('vp_rotation_allowed', False)))
-                    for row in servers
-                }
+                _srv_profile_map = _build_server_profile_map(servers)
 
                 def _row_profile(name):
                     return _srv_profile_map.get(name, ('X', False))[0]

--- a/tests/test_benchmark_best.py
+++ b/tests/test_benchmark_best.py
@@ -1,8 +1,9 @@
+import sqlite3
 import unittest
 from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
-from app.scheduler import _best_result_for_active_profile
+from app.scheduler import _best_result_for_active_profile, _build_server_profile_map
 
 
 class BenchmarkBestTest(unittest.TestCase):
@@ -34,6 +35,31 @@ class BenchmarkBestTest(unittest.TestCase):
 
         self.assertEqual(best['server'], 'Fast')
         self.assertEqual(scores['Fast'], 0.9)
+
+    def test_build_server_profile_map_accepts_sqlite_rows(self):
+        conn = sqlite3.connect(':memory:')
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute(
+                'CREATE TABLE servers ('
+                'name TEXT, vpn_profile_id INTEGER, vp_rotation_allowed INTEGER)'
+            )
+            conn.executemany(
+                'INSERT INTO servers VALUES (?, ?, ?)',
+                [('Ceibo', 1, 0), ('Germany', 2, 1)],
+            )
+            rows = conn.execute(
+                'SELECT name, vpn_profile_id, vp_rotation_allowed FROM servers'
+            ).fetchall()
+
+            profile_map = _build_server_profile_map(rows)
+
+            self.assertEqual(
+                profile_map,
+                {'Ceibo': (1, False), 'Germany': (2, True)},
+            )
+        finally:
+            conn.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #111

- avoid `.get()` on `sqlite3.Row` in the benchmark rotation path
- add a regression test using real `sqlite3.Row` records