### PR TITLE
Fix concurrent recreation of Gluetun network dependents

### DIFF
--- a/app/gluetun.py
+++ b/app/gluetun.py
@@ -78,6 +78,12 @@ def _compose_override_path(compose_dir: str) -> str:
 _companion_lock            = threading.Lock()
 _companion_restart_until: float = 0.0
 
+# Serialize dependent-container reconciliation. Docker Compose recreates are
+# transactional (rename old container -> create replacement -> rename back), so
+# two concurrent reconciliation paths can otherwise collide on temporary names
+# and leave services stranded on a dead Gluetun namespace.
+_dependent_recreate_lock = threading.Lock()
+
 
 def mark_companion_restart(suppress_secs: float = 180.0) -> None:
     """
@@ -804,7 +810,7 @@ def _cleanup_failed_compose_replacements(
     """
     removed: list[str] = []
     try:
-        entries = client.api.containers(all=True, filters={'status': ['created']})
+        entries = client.api.containers(all=True)
     except Exception as exc:
         logger.warning('Cannot inspect failed Compose replacements: %s', exc)
         return removed
@@ -823,7 +829,7 @@ def _cleanup_failed_compose_replacements(
             continue
         label = names[0] if names else cid[:12]
         try:
-            client.api.remove_container(cid, v=False, force=False)
+            client.api.remove_container(cid, v=False, force=True)
             removed.append(label)
             logger.warning(
                 'Removed abandoned Compose replacement %s for %s; retrying recreate',
@@ -926,7 +932,12 @@ def _compose_recreate(
         # Compose can abandon an intermediate replacement in ``Created`` while
         # reporting a different, already-gone temporary name.  Clean up only a
         # positively labelled replacement for this service, then retry once.
-        if ('No such container:' in last_err and
+        recoverable_compose_race = (
+            'No such container:' in last_err
+            or 'Conflict. The container name' in last_err
+            or 'Error when allocating new name: Conflict' in last_err
+        )
+        if (recoverable_compose_race and
                 _cleanup_failed_compose_replacements(
                     client, container_name, service, project,
                 )):
@@ -959,7 +970,7 @@ def _compose_recreate(
     c.restart(timeout=15)
 
 
-def restart_network_dependents(
+def _restart_network_dependents_unlocked(
     container_name: str,
     compose_dir: str = '',
     compose_project: str = '',
@@ -1067,6 +1078,26 @@ def restart_network_dependents(
     # Gluetun namespace, rather than accepting a successful Compose exit code
     # while the dependent still references the previous container ID.
     for name in names_to_restart:
+        # A second reconciliation may have captured the same stale list while
+        # waiting for the lock. If the first pass already attached this service
+        # to the current Gluetun, do not force-recreate it again.
+        current_state = _dependent_state(name)
+        if current_state and current_state.get('running'):
+            mode = current_state.get('mode', '')
+            current_refs = {f'container:{container_name}'}
+            if current_gluetun_id:
+                current_refs.update({
+                    f'container:{current_gluetun_id}',
+                    f'container:{current_gluetun_id[:12]}',
+                })
+            if mode in current_refs:
+                logger.info(
+                    'Network-dependent %s already attached to current Gluetun — skipping duplicate recreate',
+                    name,
+                )
+                restarted.append(name)
+                continue
+
         logger.info('Recreating network-dependent container: %s', name)
         try:
             if pull_set and name in pull_set:
@@ -1101,6 +1132,27 @@ def restart_network_dependents(
             logger.warning('Failed to recreate %s: %s', name, exc)
 
     return restarted, updated_imgs
+
+
+def restart_network_dependents(
+    container_name: str,
+    compose_dir: str = '',
+    compose_project: str = '',
+    exclude: set[str] | None = None,
+    pull_set: set[str] | None = None,
+    explicit_list: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Serialize dependent reconciliation across switch/event/failover paths.
+
+    Multiple background paths can notice the same Gluetun recreation.  Running
+    ``docker compose --force-recreate`` for the same dependent concurrently
+    causes Compose temporary-name conflicts and can strand the service.
+    """
+    with _dependent_recreate_lock:
+        return _restart_network_dependents_unlocked(
+            container_name, compose_dir, compose_project,
+            exclude=exclude, pull_set=pull_set, explicit_list=explicit_list,
+        )
 
 
 def _dependent_state(name: str) -> 'dict | None':

--- a/tests/test_gluetun_dependents.py
+++ b/tests/test_gluetun_dependents.py
@@ -336,7 +336,7 @@ class ComposeReplacementRecoveryTest(unittest.TestCase):
 
         self.assertEqual(run.call_count, 2)
         client.api.remove_container.assert_called_once_with(
-            'created-id', v=False, force=False,
+            'created-id', v=False, force=True,
         )
 
     @patch('app.gluetun.os.path.isdir', return_value=True)
@@ -374,6 +374,46 @@ class ComposeReplacementRecoveryTest(unittest.TestCase):
 
         client.api.remove_container.assert_not_called()
 
+
+    @patch('app.gluetun.os.path.isdir', return_value=True)
+    @patch('app.gluetun.subprocess.run')
+    @patch('docker.from_env')
+    def test_name_conflict_cleans_labelled_replacement_then_retries(
+        self, from_env, run, _isdir,
+    ):
+        current = MagicMock()
+        current.labels = {
+            'com.docker.compose.service': 'prowlarr',
+            'com.docker.compose.project': 'airvpn',
+            'com.docker.compose.project.working_dir': '/compose',
+        }
+        client = MagicMock()
+        client.containers.get.return_value = current
+        client.api.containers.return_value = [{
+            'Id': 'replacement-id',
+            'Names': ['/b1f54429e6bf_prowlarr'],
+            'Labels': {
+                'com.docker.compose.replace': 'prowlarr',
+                'com.docker.compose.service': 'prowlarr',
+                'com.docker.compose.project': 'airvpn',
+            },
+        }]
+        from_env.return_value = client
+        run.side_effect = [
+            MagicMock(
+                returncode=1,
+                stderr='Error response from daemon: Conflict. The container name "/b1f54429e6bf_prowlarr" is already in use',
+                stdout='',
+            ),
+            MagicMock(returncode=0, stderr='', stdout=''),
+        ]
+
+        _compose_recreate('prowlarr', '/compose', 'airvpn')
+
+        self.assertEqual(run.call_count, 2)
+        client.api.remove_container.assert_called_once_with(
+            'replacement-id', v=False, force=True,
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Résumé

- sérialise les réconciliations des conteneurs qui partagent le namespace réseau de Gluetun afin d'éviter que plusieurs chemins concurrents lancent `docker compose --force-recreate` sur le même service ;
- évite une recréation en double lorsqu'un autre passage a déjà rattaché le conteneur au Gluetun courant ;
- étend la récupération des remplacements Compose abandonnés aux conflits de noms observés pendant les recréations ;
- recherche les remplacements abandonnés quel que soit leur état et les supprime sans toucher aux volumes avant une seule nouvelle tentative ;
- ajoute un test de non-régression pour le cas `Conflict. The container name ... is already in use`.

## Contexte

Plusieurs réconciliations pouvaient s'exécuter en parallèle après une bascule/recréation de Gluetun. Docker Compose laissait alors des conteneurs temporaires (`<id>_prowlarr`, `<id>_qbittorrentvpn1`, etc.) et les tentatives suivantes entraient en conflit, laissant certains services liés à un ancien namespace Gluetun.

## Validation

- `python3 -m py_compile app/gluetun.py tests/test_gluetun_dependents.py`
- `git diff --check`
