### PR TITLE
Fix repeated catalogue removal notifications

### DIFF
--- a/app/catalogue.py
+++ b/app/catalogue.py
@@ -556,6 +556,26 @@ def _compute_catalogue_diff(
     return diff
 
 
+def _compute_refresh_diff(
+    before: dict[str, set[str]],
+    providers_data: dict[str, list[dict]],
+) -> dict[str, dict[str, list[str]]]:
+    """Diff only providers actually returned by a catalogue refresh.
+
+    Sidecar catalogue sources may temporarily omit a provider.  Rows for an
+    omitted provider are intentionally preserved in the database, so treating
+    the omission as a removal would emit the same false removal notification on
+    every refresh.
+    """
+    refreshed = set(providers_data)
+    before_refreshed = {p: names for p, names in before.items() if p in refreshed}
+    after = {
+        p: {str(row.get('name') or '') for row in rows if row.get('name')}
+        for p, rows in providers_data.items()
+    }
+    return _compute_catalogue_diff(before_refreshed, after)
+
+
 def _auto_add_matched_servers(
     new_entries: list[dict],
     db,
@@ -737,12 +757,12 @@ def refresh_catalogue_from_sidecar(
                     total += 1
                 provider_counts[provider] = len(servers)
 
-            # Compute diff (after snapshot → what changed)
-            after_snap: dict[str, set[str]] = {
-                p: {s['name'] for s in srvs}
-                for p, srvs in providers_data.items()
-            }
-            diff = _compute_catalogue_diff(before_snap, after_snap)
+            # Compute the diff only for providers returned by this refresh.
+            # A sidecar source can legitimately omit a provider temporarily;
+            # comparing its partial response against the entire cached catalogue
+            # would report that provider as removed on every cycle while its rows
+            # remain in the database, causing repeated Discord notifications.
+            diff = _compute_refresh_diff(before_snap, providers_data)
 
             # Auto-add new servers that match user's country/region/city filters
             if auto_add and diff:

--- a/tests/test_catalogue_options.py
+++ b/tests/test_catalogue_options.py
@@ -40,5 +40,18 @@ class CatalogueOptionsTest(unittest.TestCase):
         )
 
 
+class CataloguePartialRefreshDiffTest(unittest.TestCase):
+    def test_partial_refresh_does_not_repeat_missing_provider_removal(self):
+        from app.catalogue import _compute_refresh_diff
+
+        before = {
+            'airvpn': {'Alpheratz'},
+            'perfect privacy': {'amsterdam'},
+        }
+        providers_data = {'airvpn': [{'name': 'Alpheratz'}]}
+
+        self.assertEqual(_compute_refresh_diff(before, providers_data), {})
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Résumé

- calcule les changements du catalogue uniquement pour les providers réellement renvoyés par le rafraîchissement courant ;
- ne traite plus l'absence temporaire d'un provider dans une réponse partielle comme une suppression ;
- évite ainsi d'envoyer à répétition la même notification Discord de type `Serveurs supprimés perfect privacy -1` alors que les lignes du provider sont conservées en base ;
- ajoute un test de non-régression pour un rafraîchissement partiel.

## Contexte

Le snapshot précédent contenait tous les providers en base, alors que le snapshot suivant ne contenait que les providers renvoyés par le sidecar. Un provider temporairement absent était donc signalé comme supprimé à chaque cycle, sans être réellement supprimé de la base, ce qui répétait la notification indéfiniment.

## Validation

- `python3 -m py_compile app/catalogue.py tests/test_catalogue_options.py`
- `git diff --check`
