### PR TITLE
Stopper les notifications répétées de changements du catalogue

### DIFF
--- a/app/catalogue.py
+++ b/app/catalogue.py
@@ -316,6 +316,7 @@ def refresh_catalogue_from_local(servers_dir: str | None = None) -> dict:
         if result.get('ok'):
             result['source'] = 'local'
             result['servers_dir'] = candidate
+            set_setting('catalogue_last_source', 'local')
             return result
         last_error = result.get('error', '')
 
@@ -556,6 +557,24 @@ def _compute_catalogue_diff(
     return diff
 
 
+def catalogue_change_fingerprint(diff: dict, auto_added: list[str] | None = None) -> str:
+    # Stable SHA-256 fingerprint for one catalogue change event.
+    import hashlib
+
+    canonical = {
+        'diff': {
+            str(provider): {
+                'added': sorted(str(name) for name in changes.get('added', [])),
+                'removed': sorted(str(name) for name in changes.get('removed', [])),
+            }
+            for provider, changes in sorted((diff or {}).items())
+        },
+        'auto_added': sorted(str(name) for name in (auto_added or [])),
+    }
+    raw = json.dumps(canonical, sort_keys=True, separators=(',', ':'), ensure_ascii=True)
+    return hashlib.sha256(raw.encode('utf-8')).hexdigest()
+
+
 def _compute_refresh_diff(
     before: dict[str, set[str]],
     providers_data: dict[str, list[dict]],
@@ -726,6 +745,7 @@ def refresh_catalogue_from_sidecar(
         provider_counts: dict[str, int] = {}
         diff: dict[str, dict[str, list[str]]] = {}
         auto_added_names: list[str] = []
+        previous_source = get_setting('catalogue_last_source', '')
 
         with get_db() as db:
             # Snapshot before overwrite so we can compute the diff
@@ -764,6 +784,18 @@ def refresh_catalogue_from_sidecar(
             # remain in the database, causing repeated Discord notifications.
             diff = _compute_refresh_diff(before_snap, providers_data)
 
+            # Never diff two different catalogue representations. The mounted
+            # Gluetun catalogue and the sidecar/public catalogue can differ
+            # slightly; comparing them caused repeated "-1" notifications.
+            if previous_source and previous_source != 'sidecar':
+                if diff:
+                    logger.info(
+                        'catalogue source changed %s -> sidecar: using refresh as '
+                        'new baseline and suppressing cross-source diff',
+                        previous_source,
+                    )
+                diff = {}
+
             # Auto-add new servers that match user's country/region/city filters
             if auto_add and diff:
                 new_entries: list[dict] = []
@@ -776,6 +808,7 @@ def refresh_catalogue_from_sidecar(
                     auto_added_names = _auto_add_matched_servers(new_entries, db)
 
         set_setting('catalogue_last_refresh', datetime.utcnow().isoformat())
+        set_setting('catalogue_last_source', 'sidecar')
 
         if diff:
             change_summary = ', '.join(

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1201,7 +1201,11 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
     # loaded by the user's Gluetun container; fall back to the public sidecar
     # refresh for installs without that volume.
     try:
-        from .catalogue import refresh_catalogue_from_local, refresh_catalogue_from_sidecar
+        from .catalogue import (
+            catalogue_change_fingerprint,
+            refresh_catalogue_from_local,
+            refresh_catalogue_from_sidecar,
+        )
         _sidecar_img       = get_setting('sidecar_image', 'ghcr.io/aerya/gluetun-companion-sidecar:latest')
         _sidecar_host      = app.config['GLUETUN_HOST']
         _cat_auto_add      = get_setting('catalogue_auto_add', '0') == '1'
@@ -1222,23 +1226,43 @@ def _do_benchmark(app, skip_quick_check: bool = False, observation: bool = False
             _cat_diff       = _cat.get('diff', {})
             _cat_auto_added = _cat.get('auto_added', [])
             if _notif_cat_changes and (_cat_diff or _cat_auto_added):
-                _c_discord_url  = get_setting('discord_webhook_url') or None
-                _c_apprise_urls = get_setting('apprise_urls') or None
-                _c_lang         = get_setting('ui_lang', 'fr')
-                _c_companion    = get_setting('companion_url') or None
-                _c_mention      = get_setting('notify_mention', '').strip() or None
-                _c_mention_lvl  = get_setting('notify_mention_level', 'critical')
-                from .notify import send_catalogue_changes_notification
-                send_catalogue_changes_notification(
-                    diff=_cat_diff,
-                    auto_added=_cat_auto_added,
-                    discord_url=_c_discord_url,
-                    apprise_urls=_c_apprise_urls,
-                    lang=_c_lang,
-                    companion_url=_c_companion,
-                    mention=_c_mention,
-                    mention_level=_c_mention_lvl,
-                )
+                _cat_fp = catalogue_change_fingerprint(_cat_diff, _cat_auto_added)
+                _last_fp = get_setting('catalogue_last_notified_fingerprint', '')
+                try:
+                    _last_fp_ts = float(
+                        get_setting('catalogue_last_notified_at', '0') or '0'
+                    )
+                except (TypeError, ValueError):
+                    _last_fp_ts = 0.0
+                _cat_now = time.time()
+                _cat_dedupe_seconds = 24 * 60 * 60
+
+                if _cat_fp == _last_fp and (_cat_now - _last_fp_ts) < _cat_dedupe_seconds:
+                    logger.info(
+                        'catalogue: duplicate notification suppressed '
+                        '(same change already sent %.0f min ago)',
+                        max(0.0, (_cat_now - _last_fp_ts) / 60.0),
+                    )
+                else:
+                    _c_discord_url  = get_setting('discord_webhook_url') or None
+                    _c_apprise_urls = get_setting('apprise_urls') or None
+                    _c_lang         = get_setting('ui_lang', 'fr')
+                    _c_companion    = get_setting('companion_url') or None
+                    _c_mention      = get_setting('notify_mention', '').strip() or None
+                    _c_mention_lvl  = get_setting('notify_mention_level', 'critical')
+                    from .notify import send_catalogue_changes_notification
+                    send_catalogue_changes_notification(
+                        diff=_cat_diff,
+                        auto_added=_cat_auto_added,
+                        discord_url=_c_discord_url,
+                        apprise_urls=_c_apprise_urls,
+                        lang=_c_lang,
+                        companion_url=_c_companion,
+                        mention=_c_mention,
+                        mention_level=_c_mention_lvl,
+                    )
+                    set_setting('catalogue_last_notified_fingerprint', _cat_fp)
+                    set_setting('catalogue_last_notified_at', str(_cat_now))
         else:
             logger.warning('catalogue: refresh failed — %s', _cat.get('error', '?'))
     except Exception as _cat_exc:

--- a/tests/test_catalogue_notification_dedupe.py
+++ b/tests/test_catalogue_notification_dedupe.py
@@ -1,0 +1,28 @@
+from app.catalogue import catalogue_change_fingerprint, _compute_refresh_diff
+
+
+def test_catalogue_change_fingerprint_is_order_independent():
+    first = {
+        'provider-b': {'added': ['z', 'a'], 'removed': ['x']},
+        'provider-a': {'added': [], 'removed': ['q']},
+    }
+    second = {
+        'provider-a': {'removed': ['q'], 'added': []},
+        'provider-b': {'removed': ['x'], 'added': ['a', 'z']},
+    }
+    assert catalogue_change_fingerprint(first, ['two', 'one']) == (
+        catalogue_change_fingerprint(second, ['one', 'two'])
+    )
+
+
+def test_refresh_diff_ignores_omitted_providers():
+    before = {
+        'airvpn': {'a1', 'a2'},
+        'perfect privacy': {'p1'},
+    }
+    refreshed = {
+        'airvpn': [{'name': 'a1'}, {'name': 'a3'}],
+    }
+    assert _compute_refresh_diff(before, refreshed) == {
+        'airvpn': {'added': ['a3'], 'removed': ['a2']},
+    }


### PR DESCRIPTION
## Problème

Le catalogue local de Gluetun et le catalogue récupéré par le sidecar peuvent
légitimement différer légèrement. Si Companion alterne entre ces deux sources,
le contenu de la base peut osciller et produire à répétition des notifications
du type `provider -1` pour de nombreux fournisseurs.

Cela peut générer des dizaines de notifications Discord identiques.

## Correction

- mémorise la source ayant rempli le catalogue (`local` ou `sidecar`) ;
- lorsqu'une source change, le premier refresh devient une nouvelle baseline :
  aucun diff n'est émis entre deux représentations différentes ;
- conserve le correctif qui ignore les providers absents d'un refresh partiel ;
- ajoute un fingerprint stable du diff ;
- bloque pendant 24 h une notification strictement identique déjà envoyée ;
- ajoute des tests sur le fingerprint et les refresh partiels.

La déduplication est une sécurité supplémentaire : même si une source amont
oscille encore, Discord ne peut plus être inondé par le même événement.