### PR TITLE
Corrige la génération du token API

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3300,6 +3300,12 @@ if (document.readyState === 'loading') {
     rememberActiveTab();
 
     const submitter = event.submitter;
+    const formData = new FormData(form);
+    // FormData(form) excludes submit buttons. Preserve the clicked button so
+    // actions such as API token generation/clearing reach the backend.
+    if (submitter && submitter.name) {
+      formData.append(submitter.name, submitter.value);
+    }
     const oldHtml = submitter ? submitter.innerHTML : '';
     if (submitter) {
       submitter.disabled = true;
@@ -3309,7 +3315,7 @@ if (document.readyState === 'loading') {
     try {
       const response = await fetch(formAction.href, {
         method: 'POST',
-        body: new FormData(form),
+        body: formData,
         headers: {
           'Accept': 'application/json',
           'X-Requested-With': 'XMLHttpRequest',

--- a/tests/test_settings_template.py
+++ b/tests/test_settings_template.py
@@ -69,6 +69,15 @@ class SettingsTemplateTest(unittest.TestCase):
         self.assertIn('/Fonctionnement#custom-wireguard--serveur-personnel-unique', template)
         self.assertIn('/How-it-works#custom-wireguard-personal-single-server', template)
 
+    def test_ajax_submission_includes_clicked_button_action(self):
+        template = SETTINGS_TEMPLATE.read_text(encoding='utf-8')
+
+        self.assertIn('const submitter = event.submitter;', template)
+        self.assertIn('const formData = new FormData(form);', template)
+        self.assertIn('formData.append(submitter.name, submitter.value);', template)
+        self.assertIn('body: formData,', template)
+        self.assertNotIn('body: new FormData(form),', template)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Correctif

- conserve le bouton qui a déclenché l’envoi AJAX des réglages ;
- transmet désormais `api_token_action=generate` ou `api_token_action=clear` au backend ;
- ajoute un test de régression sur les données envoyées par le formulaire.

Le message « Settings saved » ne peut donc plus masquer une absence d’action lors de la génération ou de la suppression du token API.

Closes #120

## Validation

- 196 tests conteneurisés réussis ;
- compilation Jinja de `app/templates/settings.html` ;
- `git diff --check`.